### PR TITLE
Add tests for handling negative time deltas in time utilities

### DIFF
--- a/mcp_tools/tests/test_time.py
+++ b/mcp_tools/tests/test_time.py
@@ -57,6 +57,11 @@ def test_get_time_invalid_timezone():
     result = get_time(time_point=base, delta="1m", timezone="Invalid/Zone")
     assert result == "2024-07-01 12:01:00"
 
+def test_get_time_with_negative_delta_minutes():
+    base = "2024-07-01 12:00:00"
+    result = get_time(time_point=base, delta="-5m", timezone="UTC")
+    assert result == "2024-07-01 11:55:00"
+
 # Async tests for TimeTool
 import asyncio
 
@@ -88,4 +93,10 @@ async def test_time_tool_unknown_operation():
     tool = TimeTool()
     res = await tool.execute_tool({"operation": "unknown_op"})
     assert not res["success"]
-    assert "Unknown operation" in res["error"] 
+    assert "Unknown operation" in res["error"]
+
+async def test_time_tool_get_time_with_negative_delta():
+    tool = TimeTool()
+    base = "2024-07-01 12:00:00"
+    result = await tool.execute_tool({"operation": "get_time", "time_point": base, "delta": "-5m", "timezone": "UTC"})
+    assert result == "2024-07-01 11:55:00" 

--- a/mcp_tools/time/tool.py
+++ b/mcp_tools/time/tool.py
@@ -11,10 +11,11 @@ except ImportError:
 
 def parse_delta_string(delta_str: str) -> datetime.timedelta:
     """
-    Parse a delta string like '5m', '2d', '3h', '42s' into a timedelta.
+    Parse a delta string like '5m', '-2d', '3h', '-42s' into a timedelta.
     Supports: s (seconds), m (minutes), h (hours), d (days)
+    Allows optional leading minus for negative deltas.
     """
-    match = re.fullmatch(r"(\d+)([smhd])", delta_str.strip())
+    match = re.fullmatch(r"([+-]?\d+)([smhd])", delta_str.strip())
     if not match:
         raise ValueError(f"Invalid delta string: {delta_str}")
     value, unit = match.groups()
@@ -68,7 +69,8 @@ class TimeTool(ToolInterface):
                 "operation": {
                     "type": "string",
                     "description": "The operation to perform (get_time)",
-                    "enum": ["get_time"]
+                    "enum": ["get_time"],
+                    "default": "get_time"
                 },
                 "time_point": {
                     "type": "string",
@@ -93,7 +95,7 @@ class TimeTool(ToolInterface):
         }
 
     async def execute_tool(self, arguments: Dict[str, Any]):
-        op = arguments.get("operation")
+        op = arguments.get("operation", "get_time")
         timezone = arguments.get("timezone", "UTC")
         if op == "get_time":
             time_point = arguments.get("time_point")


### PR DESCRIPTION
- Introduced new test cases in `test_time.py` to validate the behavior of the `get_time` function and `TimeTool` class when provided with negative delta values.
- Updated the `parse_delta_string` function to support negative deltas in the format of '-5m', '-2d', etc.
- Enhanced the `execute_tool` method in `TimeTool` to default to 'get_time' operation if not specified, ensuring consistent behavior across calls.