### PR TITLE
Update cursor MCP configuration - remove GitHub server config

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -3,20 +3,6 @@
     "self": {
       "url": "http://localhost:8000/sse",
       "env": {}
-    },
-    "github": {
-      "command": "docker",
-      "args": [
-        "run",
-        "-i",
-        "--rm",
-        "-e",
-        "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "ghcr.io/github/github-mcp-server"
-      ],
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${env.GITHUB_PERSONAL_ACCESS_TOKEN}"
-      }
     }
   }
 }


### PR DESCRIPTION
This PR removes the GitHub server configuration from the cursor MCP configuration file. The GitHub server config was causing issues and is no longer needed for the current setup.