### PR TITLE
Fix: Remove unnecessary --project parameter from workitem get operation

### DIFF
--- a/plugins/azrepo/workitem_tool.py
+++ b/plugins/azrepo/workitem_tool.py
@@ -281,7 +281,7 @@ class AzureWorkItemTool(ToolInterface):
         Args:
             work_item_id: ID of the work item
             organization: Azure DevOps organization URL (uses configured default if not provided)
-            project: Azure DevOps project name/ID (uses configured default if not provided)
+            project: Azure DevOps project name/ID (accepted for compatibility but not used - work item IDs are globally unique within an organization)
             as_of: Work item details as of a particular date and time
             expand: The expand parameters for work item attributes (all, fields, links, none, relations)
             fields: Comma-separated list of requested fields
@@ -293,13 +293,11 @@ class AzureWorkItemTool(ToolInterface):
 
         # Use configured defaults for core parameters
         org = self._get_param_with_default(organization, self.default_organization)
-        proj = self._get_param_with_default(project, self.default_project)
+        # Note: project parameter is not used for work item retrieval as work item IDs are globally unique within an organization
 
         # Add optional parameters
         if org:
             command += f" --org {org}"
-        if proj:
-            command += f" --project {proj}"
         if as_of:
             command += f" --as-of '{as_of}'"
         if expand:


### PR DESCRIPTION
## Description

This PR fixes issue #15 by removing the unnecessary `--project` parameter from the `az boards work-item show` command in the `get_work_item` method.

## Problem

The `get_work_item` method was incorrectly adding the `--project` parameter to the Azure CLI command, which is not needed because work item IDs are globally unique within an Azure DevOps organization.

## Changes Made

- **Removed** the `--project` parameter from the `az boards work-item show` command in the `get_work_item` method
- **Updated** the docstring to clarify that the project parameter is accepted for compatibility but not used
- **Added** explanatory comment in the code about why the project parameter is not used

## Technical Details

- Work item IDs are globally unique within an Azure DevOps organization
- The `az boards work-item show` command only requires the organization and work item ID
- The `create_work_item` method correctly continues to use the `--project` parameter as it's required for work item creation

## Testing

- ✅ All existing tests pass (101/101 tests in azrepo plugin)
- ✅ No test changes required as the existing tests already expect the correct behavior
- ✅ The change is backward compatible - the project parameter is still accepted but simply ignored

## Files Changed

- `plugins/azrepo/workitem_tool.py` - Removed project parameter usage in get_work_item method

## Verification

The fix ensures that:
1. Work item retrieval works correctly without unnecessary parameters
2. The API remains backward compatible
3. Create operations continue to work as expected with project parameters
4. All existing functionality is preserved

Fixes #15