### PR TITLE
Update GitHub workflow to emphasize main branch checkout and remove master references

### DIFF
--- a/prompt/github_issue_workflow.md
+++ b/prompt/github_issue_workflow.md
@@ -6,6 +6,15 @@ Your primary task is to read a GitHub issue, understand the requirements, implem
 
 ## Workflow Steps
 
+### 0. Pre-Work Setup
+
+**⚠️ IMPORTANT: Always start by checking out the main branch**
+```bash
+git checkout main
+git pull origin main
+```
+This ensures you're working from the latest stable code and prevents conflicts.
+
 ### 1. Issue Analysis Phase
 
 **Read and Understand the Issue:**
@@ -30,8 +39,9 @@ Your primary task is to read a GitHub issue, understand the requirements, implem
 - Identify any dependencies or prerequisites
 
 **Branch Management:**
+- **First, ensure you're on the main branch with latest changes** (see Pre-Work Setup above)
 - Create a new feature branch with a descriptive name (e.g., `fix/issue-123-description` or `feature/issue-456-new-feature`)
-- Ensure you're working from the latest main/master branch
+- Verify you're working from the latest main branch
 
 ### 3. Implementation Phase
 


### PR DESCRIPTION
## Summary

This PR updates the GitHub issue workflow documentation to improve clarity around git branch management and modernize branch naming conventions.

## Changes Made

### 1. Added Prominent Pre-Work Setup Section
- Added a new "Pre-Work Setup" section (step 0) at the beginning of the workflow
- Includes clear git commands with warning emoji for visibility:
  ```bash
  git checkout main
  git pull origin main
  ```
- Explains the importance of starting from the latest stable code

### 2. Enhanced Branch Management Instructions
- Updated the Planning Phase to reference the Pre-Work Setup section
- Made it clear that checking out main should be done first
- Improved the flow between sections

### 3. Removed Master Branch References
- Removed all references to "master" branch
- Now consistently uses only "main" throughout the document
- Aligns with modern Git best practices

## Why These Changes Matter

- **Prevents merge conflicts**: Ensures developers always start from the latest main branch
- **Improves workflow clarity**: Makes the git checkout step impossible to miss
- **Modernizes documentation**: Removes outdated master branch references
- **Enhances developer experience**: Clear, step-by-step instructions reduce errors

## Files Changed

- `prompt/github_issue_workflow.md` - Updated workflow documentation

## Testing

- [x] Verified all git commands are correct
- [x] Confirmed markdown formatting renders properly
- [x] Checked that workflow steps are logical and complete