### PR TITLE
Add repository identification to GitHub issue generation rule

### DIFF
--- a/.cursor/rules/generate_github_issue.mdc
+++ b/.cursor/rules/generate_github_issue.mdc
@@ -11,6 +11,16 @@ You are an expert GitHub issue creator who specializes in translating user reque
 
 When a user requests to create a GitHub issue, follow these guidelines to create a comprehensive, well-structured issue:
 
+### Repository Identification
+**IMPORTANT**: Before creating any GitHub issue, always check the actual repository information:
+
+1. **Check Git Remote**: Run `git remote -v` to identify the correct repository owner and name
+2. **Parse Repository URL**: Extract the owner and repository name from the remote URL
+   - For SSH URLs like `git@github.com:owner/repo.git`, extract `owner` and `repo`
+   - For HTTPS URLs like `https://github.com/owner/repo.git`, extract `owner` and `repo`
+3. **Use Actual Repository**: Always use the actual repository information from git remote, not assumed or placeholder values
+4. **Verify Access**: Ensure you have the correct repository details before attempting to create the issue
+
 ### Issue Analysis
 1. **Understand the Request**: Carefully analyze the user's request to identify:
    - The type of issue (bug, feature request, enhancement, documentation, etc.)
@@ -72,3 +82,4 @@ Before finalizing, ensure:
 - Technical details are accurate
 - The scope is appropriate (not too large or too small)
 - All necessary context is provided
+- **Repository information is correct** (verified via git remote)


### PR DESCRIPTION
## Summary

This PR enhances the GitHub issue generation cursor rule (`.cursor/rules/generate_github_issue.mdc`) by adding mandatory repository identification steps to prevent issues from being created in the wrong repositories.

## Changes Made

### New Repository Identification Section
- Added a new "Repository Identification" section that comes before issue analysis
- Requires checking `git remote -v` before creating any GitHub issues
- Provides clear instructions for parsing both SSH and HTTPS repository URLs
- Emphasizes using actual repository information rather than assumptions

### Enhanced Quality Checks
- Added repository verification to the final quality checklist
- Ensures all GitHub issues are created with correct owner/repo information

## Problem Solved

Previously, the cursor rule could lead to issues being created in incorrect repositories when users assumed repository details. This update ensures that:

1. **Correct Repository Targeting**: Always uses actual git remote information
2. **Reduced Manual Errors**: Eliminates guesswork about repository ownership  
3. **Improved Workflow**: Makes repository identification a standard first step
4. **Better Documentation**: Clear instructions for handling different URL formats

## Testing

- ✅ Updated rule successfully prevents incorrect repository targeting
- ✅ Clear instructions for both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) formats
- ✅ Repository verification added to quality checklist

## Impact

This change improves the reliability of the GitHub issue creation workflow and prevents issues from being created in wrong repositories, which was demonstrated to be a real problem in recent usage.

## Files Changed

- `.cursor/rules/generate_github_issue.mdc` - Enhanced with repository identification requirements