### PR TITLE
Fix test failures due to missing "disk-sleep" process status in assertions (Issue #41)

### DIFF
--- a/mcp_tools/tests/test_command_executor_async.py
+++ b/mcp_tools/tests/test_command_executor_async.py
@@ -143,7 +143,8 @@ class TestCommandExecutorAsync:
         assert status["status"] in [
             "running",
             "sleeping",
-        ]  # Process could be in running or sleeping state
+            "disk-sleep",
+        ]  # Process could be in running, sleeping, or disk-sleep state
 
         # Wait for completion
         await asyncio.sleep(3)  # Wait a bit longer for Windows
@@ -255,6 +256,7 @@ class TestCommandExecutorAsync:
             assert status["status"] in [
                 "running",
                 "sleeping",
+                "disk-sleep",
                 "completed",
             ]  # May complete quickly
 


### PR DESCRIPTION
## Description

This PR fixes test failures that occur on some systems where processes can enter the "disk-sleep" state, which was not included in the test assertions.

## Problem

The tests `test_query_process_no_wait` and `test_concurrent_processes` in `mcp_tools/tests/test_command_executor_async.py` were failing with:
```
AssertionError: assert 'disk-sleep' in ['running', 'sleeping']
```

The "disk-sleep" status is a valid process state on Unix-like systems that occurs when a process is waiting for disk I/O operations to complete.

## Changes Made

### ✅ Fixed Assertions in Two Test Methods

1. **`test_query_process_no_wait` (lines 142-145)**:
   - **Before**: `assert status["status"] in ["running", "sleeping"]`
   - **After**: `assert status["status"] in ["running", "sleeping", "disk-sleep"]`

2. **`test_concurrent_processes` (lines 254-258)**:
   - **Before**: `assert status["status"] in ["running", "sleeping", "completed"]`
   - **After**: `assert status["status"] in ["running", "sleeping", "disk-sleep", "completed"]`

### 🔄 Consistency with Existing Code

The fix maintains consistency with the existing `test_terminate_by_token` method, which already properly handles "disk-sleep":
```python
ACTIVE_STATES = {"running", "sleeping", "disk-sleep"}
```

## Testing

- ✅ All tests in `mcp_tools/tests/test_command_executor_async.py` pass (14/14)
- ✅ Specifically tested both modified methods individually
- ✅ No regressions introduced

## Acceptance Criteria Fulfilled

- [x] Fix the assertion in `test_query_process_no_wait` (lines 142-145) to include "disk-sleep"
- [x] Fix the similar assertion in `test_concurrent_processes` (lines 254-258) to include "disk-sleep"  
- [x] Ensure all tests pass on systems where processes can enter "disk-sleep" state
- [x] Maintain consistency with the existing `ACTIVE_STATES` pattern used elsewhere in the codebase

## Impact

- **Scope**: Test-only fix that improves compatibility across different systems
- **Risk**: Low - only adds an additional valid process state to existing assertions
- **Compatibility**: Improves test reliability on systems where disk I/O can cause processes to enter "disk-sleep" state

Closes #41