### PR TITLE
Fix optional BrowserClient import

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["pytest_asyncio"]

--- a/mcp_tools/__init__.py
+++ b/mcp_tools/__init__.py
@@ -11,7 +11,14 @@ from mcp_tools.interfaces import (
 
 # Import concrete implementations
 from mcp_tools.command_executor import CommandExecutor
-from mcp_tools.browser import BrowserClient
+
+# BrowserClient requires optional selenium/playwright dependencies. Avoid failing
+# on import if those packages are not installed by lazily importing the class.
+try:  # pragma: no cover - optional dependency
+    from mcp_tools.browser import BrowserClient
+except Exception:  # pragma: no cover - missing optional deps
+    BrowserClient = None  # type: ignore
+
 from config import env
 
 # Import plugin system

--- a/mcp_tools/tests/conftest.py
+++ b/mcp_tools/tests/conftest.py
@@ -1,8 +1,5 @@
 import pytest
 
-# Configure pytest-asyncio to use auto mode
-pytest_plugins = ["pytest_asyncio"]
-
 
 def pytest_configure(config):
     """Add custom markers for tests"""


### PR DESCRIPTION
## Summary
- avoid mandatory selenium dependency by lazily importing `BrowserClient`
- remove deprecated pytest_plugins from submodule conftest
- add root-level conftest for pytest-asyncio

## Testing
- `pytest mcp_core/tests/test_tools.py -q`
- `pytest mcp_tools/tests/test_plugin_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68436ea5e42883229691f17794924bba