### PR TITLE
Update default test timeout in pyproject.toml from 5 minutes to 1 min…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,5 +124,5 @@ disallow_incomplete_defs = true
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 asyncio_default_fixture_loop_scope = "function"
-timeout = 300  # 5 minutes default timeout per test
+timeout = 60  # 1 minute default timeout per test
 timeout_method = "thread"  # Use thread-based timeout (more reliable than signal)


### PR DESCRIPTION
…ute for improved test efficiency.