### PR TITLE
Update cursor rules to always use uv instead of python/pip

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -3,6 +3,12 @@ description:
 globs:
 alwaysApply: true
 ---
-1. Use uv for package management instead of pip
+1. Always use uv instead of python/pip for all package management and Python execution:
+   - Use `uv run` instead of `python`
+   - Use `uv add` instead of `pip install`
+   - Use `uv remove` instead of `pip uninstall`
+   - Use `uv sync` instead of `pip install -r requirements.txt`
+   - Use `uv lock` to update dependencies
+   - Use `uv venv` for virtual environment creation
 2. Do not generate readme markdown files unless I explicitly ask
 3. Do not generate example unless I explicitly ask


### PR DESCRIPTION
## Summary
Enhanced the cursor rules to be more comprehensive about using `uv` instead of `python/pip` for all package management and Python execution.

## Changes
- Updated rule 1 in `.cursor/rules/general.mdc` to include specific command mappings:
  - Use `uv run` instead of `python`
  - Use `uv add` instead of `pip install`
  - Use `uv remove` instead of `pip uninstall`
  - Use `uv sync` instead of `pip install -r requirements.txt`
  - Use `uv lock` to update dependencies
  - Use `uv venv` for virtual environment creation

## Benefits
- Ensures consistent use of `uv` across all Python development tasks
- Provides clear command mappings for developers and AI assistants
- Improves development workflow consistency