### PR TITLE
Update cursor rules: Add guidance to use existing venv when available

### DIFF
--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -9,6 +9,6 @@ alwaysApply: true
    - Use `uv remove` instead of `pip uninstall`
    - Use `uv sync` instead of `pip install -r requirements.txt`
    - Use `uv lock` to update dependencies
-   - Use `uv venv` for virtual environment creation
+   - Use existing virtual environment if available, otherwise use `uv venv` for virtual environment creation
 2. Do not generate readme markdown files unless I explicitly ask
 3. Do not generate example unless I explicitly ask

--- a/.cursor/rules/github_issue_workflow.mdc
+++ b/.cursor/rules/github_issue_workflow.mdc
@@ -21,6 +21,13 @@ git checkout main && git pull origin main
 ```
 This ensures you're working from the latest stable code and prevents conflicts.
 
+**Environment Setup:**
+- Use existing virtual environment if available, otherwise create one with `uv venv`
+- Always use uv instead of python/pip for all package management and Python execution:
+  - Use `uv run` instead of `python`
+  - Use `uv add` instead of `pip install`
+  - Use `uv sync` to install dependencies from lock file
+
 ### 1. Issue Analysis Phase
 
 **Read and Understand the Issue:**


### PR DESCRIPTION
## Summary

This PR updates both cursor rules files to include guidance about using existing virtual environments when they are available, rather than always creating new ones.

**Developed using Cursor**

## Changes Made

### 1. `general.mdc`
- Updated the virtual environment creation rule to prioritize existing environments
- Changed from: `Use uv venv for virtual environment creation`
- To: `Use existing virtual environment if available, otherwise use uv venv for virtual environment creation`

### 2. `github_issue_workflow.mdc`
- Added a new **Environment Setup** section in the Pre-Work Setup phase
- Includes guidance to use existing virtual environment if available
- Reinforces the use of uv commands for package management
- Provides specific uv command examples (`uv run`, `uv add`, `uv sync`)

## Benefits

- More efficient development workflow by reusing existing environments
- Consistent guidance across both cursor rules files
- Better alignment with modern Python development practices
- Reduces setup time and potential environment conflicts

## Testing

- Files have been formatted and pass pre-commit hooks
- No functional changes to code, only documentation updates