### PR TITLE
Simplify work-in-progress guidance: Just add a tag

### DIFF
--- a/.cursor/rules/github_issue_workflow.mdc
+++ b/.cursor/rules/github_issue_workflow.mdc
@@ -59,12 +59,7 @@ This ensures you're working from the latest stable code and prevents conflicts.
 ### 3. Implementation Phase
 
 **⚠️ FIRST STEP: Mark Issue as Work-in-Progress**
-- **Immediately after creating your branch and before making any code changes**, add a work-in-progress tag or label to the GitHub issue
-- This signals to other team members that the issue is actively being worked on
-- Common approaches:
-  - Add a "work-in-progress" or "WIP" label to the issue
-  - Comment on the issue stating you've started working on it (e.g., "🚧 Started working on this issue in branch `fix/issue-123-description`")
-  - If your project uses assignees, assign yourself to the issue
+- **Immediately after creating your branch and before making any code changes**, add a work-in-progress tag to the GitHub issue
 - This prevents duplicate work and improves team coordination
 
 **Code Changes:**


### PR DESCRIPTION
## Summary

This PR simplifies the work-in-progress guidance in the GitHub issue workflow to be more concise and focused.

**Developed using Cursor**

## Changes Made

### `github_issue_workflow.mdc`
- Simplified the "Mark Issue as Work-in-Progress" section
- Removed detailed list of approaches and examples
- Streamlined to just mention adding a work-in-progress tag
- Maintained the core message about preventing duplicate work

## Before
```
**⚠️ FIRST STEP: Mark Issue as Work-in-Progress**
- **Immediately after creating your branch and before making any code changes**, add a work-in-progress tag or label to the GitHub issue
- This signals to other team members that the issue is actively being worked on
- Common approaches:
  - Add a "work-in-progress" or "WIP" label to the issue
  - Comment on the issue stating you've started working on it (e.g., "🚧 Started working on this issue in branch `fix/issue-123-description`")
  - If your project uses assignees, assign yourself to the issue
- This prevents duplicate work and improves team coordination
```

## After
```
**⚠️ FIRST STEP: Mark Issue as Work-in-Progress**
- **Immediately after creating your branch and before making any code changes**, add a work-in-progress tag to the GitHub issue
- This prevents duplicate work and improves team coordination
```

## Benefits

- More concise and easier to follow
- Reduces cognitive load while maintaining essential guidance
- Focuses on the core action needed
- Maintains the important timing and purpose of the step