### PR TITLE
fix: Use Bearer authentication instead of Basic for Azure DevOps REST API

### DIFF
--- a/plugins/azrepo/workitem_tool.py
+++ b/plugins/azrepo/workitem_tool.py
@@ -244,12 +244,9 @@ class AzureWorkItemTool(ToolInterface):
         if not self.bearer_token:
             raise ValueError("Bearer token not configured. Please set AZREPO_BEARER_TOKEN environment variable.")
         
-        # For Azure DevOps REST API, we can use the bearer token directly
-        # or encode it as Basic auth with empty username
-        credentials = base64.b64encode(f":{self.bearer_token}".encode()).decode()
-        
+        # For Azure DevOps REST API, use the bearer token directly
         return {
-            "Authorization": f"Basic {credentials}",
+            "Authorization": f"Bearer {self.bearer_token}",
             "Content-Type": "application/json-patch+json",
             "Accept": "application/json"
         }


### PR DESCRIPTION
## Summary

This PR fixes the authentication method used in the Azure DevOps Work Item tool to use Bearer authentication instead of Basic authentication.

## Changes

- Updated `_get_auth_headers()` method in `plugins/azrepo/workitem_tool.py`
- Changed from `Authorization: Basic {base64_encoded_credentials}` to `Authorization: Bearer {token}`
- Removed unnecessary base64 encoding logic
- Updated comments to reflect the correct authentication method

## Why this change?

The previous implementation was using Basic authentication with base64 encoding, but Azure DevOps REST API supports and prefers Bearer token authentication when using personal access tokens or other bearer tokens. This change:

1. Simplifies the authentication logic
2. Aligns with Azure DevOps REST API best practices
3. Makes the code more readable and maintainable

## Testing

The change maintains the same interface and error handling, only modifying the authentication header format.