### PR TITLE
Fix parallel test script argument parsing and enable parallel CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           source .venv/bin/activate
           chmod +x ./scripts/run_tests.sh
-          ./scripts/run_tests.sh
+          ./scripts/run_tests.sh -p 4
 
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
@@ -92,7 +92,7 @@ jobs:
         run: |
           source .venv/Scripts/activate
           chmod +x ./scripts/run_tests.sh
-          ./scripts/run_tests.sh
+          ./scripts/run_tests.sh -p 4
 
       - name: Cleanup Temporary Files (Unix)
         if: always() && runner.os != 'Windows'

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -158,10 +158,32 @@ process_parallel_results() {
     echo ""
 }
 
-# Parse optional test pattern argument, parallel flag, and max parallel jobs
-TEST_PATTERN="$1"
-PARALLEL_MODE="$2"
-MAX_PARALLEL_JOBS="${3:-4}"  # Default to 4 parallel jobs
+# Parse arguments - handle different orders and combinations
+TEST_PATTERN=""
+PARALLEL_MODE=""
+MAX_PARALLEL_JOBS="4"
+
+# Parse all arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --parallel|-p)
+            PARALLEL_MODE="--parallel"
+            shift
+            # Check if next argument is a number (max jobs)
+            if [[ $1 =~ ^[0-9]+$ ]]; then
+                MAX_PARALLEL_JOBS="$1"
+                shift
+            fi
+            ;;
+        *)
+            # If it's not a flag and we don't have a test pattern yet, use it as test pattern
+            if [[ -z "$TEST_PATTERN" ]]; then
+                TEST_PATTERN="$1"
+            fi
+            shift
+            ;;
+    esac
+done
 
 # Check if parallel mode is requested
 if [[ "$PARALLEL_MODE" == "--parallel" || "$PARALLEL_MODE" == "-p" ]]; then


### PR DESCRIPTION
## Summary

This PR fixes the argument parsing issue in the `run_tests.sh` script that was preventing the parallel mode (`-p` flag) from working correctly.

**Developed using Cursor**

## Problem

The original script used simple positional argument parsing (`$1`, `$2`, `$3`) which caused issues when running commands like `./run_tests.sh -p 4`:
- The `-p` flag was incorrectly interpreted as a test pattern instead of the parallel mode flag
- This caused pytest to receive `-k "-p"` which resulted in argument parsing errors
- The script would fall back to sequential mode instead of running in parallel

## Solution

- **Replaced positional argument parsing with proper case-based parsing** using a `while` loop and `case` statements
- **Added support for flexible argument order** - now supports:
  - `./run_tests.sh -p 4` (parallel with 4 jobs)
  - `./run_tests.sh --parallel` (parallel with default 4 jobs)  
  - `./run_tests.sh "test_pattern" -p 2` (test pattern with parallel)
  - `./run_tests.sh -p 8 "test_pattern"` (parallel first, then test pattern)
- **Updated GitHub Actions workflow** to use parallel testing with 4 concurrent jobs for faster CI runs

## Changes Made

### `scripts/run_tests.sh`
- Replaced simple positional argument parsing with robust case-based parsing
- Added proper handling of `-p`/`--parallel` flags with optional job count parameter
- Maintained backward compatibility with existing usage patterns

### `.github/workflows/tests.yml`
- Updated test execution to use `./run_tests.sh -p 4` for parallel testing
- Applied to both Unix and Windows test runners

## Testing

✅ Verified the script now correctly:
- Recognizes `-p` and `--parallel` flags
- Starts tests in parallel mode with proper job limiting
- Handles different argument orders correctly
- Falls back gracefully when parallel mode is not requested

## Impact

- **Faster CI runs** through parallel test execution
- **Improved developer experience** with working parallel test script
- **Better resource utilization** during testing
- **No breaking changes** - maintains full backward compatibility