### PR TITLE
Add 30-minute timeout to GitHub Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

This PR adds a 30-minute timeout to the GitHub Actions test workflow to prevent long-running tests from consuming excessive CI resources.

## Changes

- Added `timeout-minutes: 30` to the test job in `.github/workflows/tests.yml`
- This ensures the workflow fails fast if tests hang or take too long
- Improves CI efficiency and resource usage

## Benefits

- Prevents workflows from running indefinitely
- Reduces CI costs and resource consumption
- Provides faster feedback when tests are stuck or hanging
- Aligns with best practices for CI/CD pipelines

## Testing

The timeout configuration has been added to the workflow file and will take effect on the next workflow run.