### PR TITLE
Add Ollama client

### DIFF
--- a/docs/utils_overview.md
+++ b/docs/utils_overview.md
@@ -95,4 +95,17 @@ This document provides a high-level overview of the utilities available in the `
 
 ---
 
+## LLM Clients (`llm_clients`)
+
+**Functionality:**
+- Async wrappers for interacting with LLM backends.
+- Includes clients for OpenAI and the local Ollama server.
+
+**Usage:**
+- `OpenAIClient(api_key, base_url, default_model)` for OpenAI or Azure OpenAI APIs.
+- `OllamaClient(base_url, default_model)` for local models via the Ollama service.
+- Useful for integrating chat completion features into tools and plugins.
+
+---
+
 For more details, see the source code and inline documentation in each utility folder.

--- a/utils/llm_clients/__init__.py
+++ b/utils/llm_clients/__init__.py
@@ -1,1 +1,7 @@
-# LLM Clients package for OpenAI and Azure OpenAI integrations
+"""Async LLM client utilities."""
+
+from .openai_client import LLMCompletionClient, OpenAIClient
+from .ollama_client import OllamaClient
+
+__all__ = ["LLMCompletionClient", "OpenAIClient", "OllamaClient"]
+

--- a/utils/llm_clients/ollama_client.py
+++ b/utils/llm_clients/ollama_client.py
@@ -1,0 +1,32 @@
+"""Async Ollama LLM client using httpx."""
+
+from typing import Dict, Any, List
+import httpx
+
+
+class OllamaClient:
+    """Async client for the Ollama `/api/chat` endpoint."""
+
+    def __init__(self, base_url: str = "http://localhost:11434", default_model: str | None = None):
+        self.async_client = httpx.AsyncClient(base_url=base_url)
+        self.default_model = default_model
+
+    async def completion(
+        self, messages: List[Dict[str, Any]], model: str | None = None, **kwargs
+    ) -> Dict[str, Any]:
+        """Run a chat completion via the Ollama API."""
+        model_to_use = model or self.default_model
+        if not model_to_use:
+            raise ValueError("No model specified and no default_model set.")
+        payload = {"model": model_to_use, "messages": messages, **kwargs}
+        try:
+            response = await self.async_client.post("/api/chat", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"LLM API error: {e}") from e
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self.async_client.aclose()
+


### PR DESCRIPTION
## Summary
- add an async Ollama client alongside OpenAI utils
- export Ollama client in llm_clients package
- document LLM client utilities

## Testing
- `./scripts/run_tests.sh` *(fails: Failed to download `matplotlib==3.10.3`)*

------
https://chatgpt.com/codex/tasks/task_e_684a37008dc4832f80b7888d56b4e21b