### PR TITLE
Refactor: Remove backward compatibility methods and update username r…

### DIFF
--- a/plugins/azrepo/README_REST_UTILS.md
+++ b/plugins/azrepo/README_REST_UTILS.md
@@ -56,13 +56,19 @@ When migrating existing code to use these shared utilities:
 
 ## Backward Compatibility
 
-For backward compatibility with existing tests, wrapper methods have been added to the original classes:
+All backward compatibility wrapper methods have been completely removed from both tools. The methods that were removed include:
 
-- `_get_auth_headers()` - Delegates to the shared utility
-- `_get_current_username()` - Delegates to the shared utility
-- `_build_api_url()` - Delegates to the shared utility
+- **From AzureWorkItemTool**: `_get_auth_headers()`, `_get_current_username()`
+- **From AzurePullRequestTool**: `_get_auth_headers()`, `_get_current_username()`
 
-These methods maintain the original interface while using the shared implementations.
+These methods were either only used in tests or have been replaced with direct calls to shared utilities in production code. This results in:
+
+- **Cleaner code**: No unnecessary wrapper methods
+- **Better maintainability**: Direct calls to shared utilities
+- **Improved testability**: Tests mock the shared utilities directly
+- **Consistency**: Both tools follow the same pattern
+
+All production code now calls the shared utility functions directly, and tests have been updated to mock the appropriate functions where they are imported and used.
 
 ## Testing
 
@@ -88,4 +94,4 @@ Potential future improvements to the shared utilities:
 1. Add support for additional authentication methods
 2. Implement retry logic for transient API failures
 3. Add caching for frequently used responses
-4. Create higher-level API helpers for common operations 
+4. Create higher-level API helpers for common operations

--- a/plugins/azrepo/pr_tool.py
+++ b/plugins/azrepo/pr_tool.py
@@ -375,7 +375,7 @@ class AzurePullRequestTool(ToolInterface):
         Returns:
             Default prefix in format 'auto-pr/<username>/' or 'auto-pr' if username unavailable
         """
-        username = self._get_current_username()
+        username = get_current_username()
         if username:
             return f"auto-pr/{username}/"
         else:
@@ -576,7 +576,7 @@ class AzurePullRequestTool(ToolInterface):
 
             # Handle creator parameter with default behavior
             if creator == "default":
-                creator_id = self._get_current_username()
+                creator_id = get_current_username()
                 if creator_id:
                     # Resolve local username to Azure DevOps identity
                     try:
@@ -837,7 +837,7 @@ class AzurePullRequestTool(ToolInterface):
                     "squashMerge": squash,
                     "mergeStrategy": "squash" if squash else "merge"
                 }
-                request_body["autoCompleteSetBy"] = {"id": self._get_current_username()}
+                request_body["autoCompleteSetBy"] = {"id": get_current_username()}
 
             # Make REST API call to update PR
             async with AzureHttpClient() as http_client:
@@ -907,7 +907,7 @@ class AzurePullRequestTool(ToolInterface):
             # Handle auto-complete
             if auto_complete is not None:
                 if auto_complete:
-                    current_user = self._get_current_username()
+                    current_user = get_current_username()
                     if current_user:
                         request_body["autoCompleteSetBy"] = {"id": current_user}
                 else:
@@ -957,7 +957,7 @@ class AzurePullRequestTool(ToolInterface):
                 return {"success": False, "error": "Organization, project, and repository are required"}
 
             # Get current user ID for reviewer endpoint
-            current_user = self._get_current_username()
+            current_user = get_current_username()
             if not current_user:
                 return {"success": False, "error": "Unable to determine current user for voting"}
 
@@ -1392,18 +1392,3 @@ class AzurePullRequestTool(ToolInterface):
             )
         else:
             return {"success": False, "error": f"Unknown operation: {operation}"}
-
-    # Backward compatibility methods for tests
-    def _get_current_username(self) -> Optional[str]:
-        """Backward compatibility method for tests."""
-        # Convert potential bytes to string if needed
-        username = get_current_username()
-        if isinstance(username, bytes):
-            return username.decode("utf-8")
-        return username
-
-    def _get_auth_headers(
-        self, content_type: str = "application/json"
-    ) -> Dict[str, str]:
-        """Backward compatibility method for tests."""
-        return get_auth_headers(content_type=content_type)

--- a/plugins/azrepo/tests/test_bearer_token_command.py
+++ b/plugins/azrepo/tests/test_bearer_token_command.py
@@ -137,7 +137,8 @@ class TestBearerTokenCommand:
         tool = AzureWorkItemTool(command_executor=mock_executor)
 
         # Get auth headers - this should trigger dynamic token loading
-        headers = tool._get_auth_headers()
+        from plugins.azrepo.azure_rest_utils import get_auth_headers
+        headers = get_auth_headers(content_type="application/json-patch+json")
 
         # Verify the token was loaded dynamically
         assert "Authorization" in headers
@@ -156,7 +157,8 @@ class TestBearerTokenCommand:
         tool = AzureWorkItemTool(command_executor=mock_executor)
 
         # Get auth headers
-        headers = tool._get_auth_headers()
+        from plugins.azrepo.azure_rest_utils import get_auth_headers
+        headers = get_auth_headers(content_type="application/json-patch+json")
 
         # Verify the static token was used
         assert "Authorization" in headers
@@ -171,7 +173,8 @@ class TestBearerTokenCommand:
 
         # Getting auth headers should raise an error
         with pytest.raises(ValueError, match="Bearer token not configured"):
-            tool._get_auth_headers()
+            from plugins.azrepo.azure_rest_utils import get_auth_headers
+            get_auth_headers(content_type="application/json-patch+json")
 
     @patch("plugins.azrepo.azure_rest_utils.subprocess.run")
     def test_multiple_auth_header_calls_refresh_token(self, mock_subprocess_run, mock_executor, mock_env_manager_with_token_command):
@@ -187,9 +190,10 @@ class TestBearerTokenCommand:
         tool = AzureWorkItemTool(command_executor=mock_executor)
 
         # Call get_auth_headers multiple times
-        headers1 = tool._get_auth_headers()
-        headers2 = tool._get_auth_headers()
-        headers3 = tool._get_auth_headers()
+        from plugins.azrepo.azure_rest_utils import get_auth_headers
+        headers1 = get_auth_headers(content_type="application/json-patch+json")
+        headers2 = get_auth_headers(content_type="application/json-patch+json")
+        headers3 = get_auth_headers(content_type="application/json-patch+json")
 
         # Verify all calls returned the same token (since our mock returns the same value)
         assert headers1["Authorization"] == "Bearer dynamic-token-from-command-123"
@@ -229,7 +233,7 @@ class TestBearerTokenCommand:
             # Verify that the request was made
             mock_client_class.return_value.request.assert_called_once()
             call_args = mock_client_class.return_value.request.call_args
-            
+
             # Verify the method and headers
             assert call_args[0][0] == "POST"  # method
             headers = call_args[1]["headers"]

--- a/plugins/azrepo/tests/test_integration_bearer_token.py
+++ b/plugins/azrepo/tests/test_integration_bearer_token.py
@@ -179,7 +179,8 @@ class TestBearerTokenCommandIntegration:
 
                 # Attempting to get auth headers should raise a clear error
                 with pytest.raises(ValueError, match="Bearer token not configured"):
-                    tool._get_auth_headers()
+                    from plugins.azrepo.azure_rest_utils import get_auth_headers
+                    get_auth_headers(content_type="application/json-patch+json")
 
                 # Verify the command was attempted
                 mock_subprocess_run.assert_called_once()
@@ -211,7 +212,8 @@ class TestBearerTokenCommandIntegration:
                 tool = AzureWorkItemTool(command_executor=mock_executor)
 
                 # Get auth headers should use static token
-                headers = tool._get_auth_headers()
+                from plugins.azrepo.azure_rest_utils import get_auth_headers
+                headers = get_auth_headers(content_type="application/json-patch+json")
 
                 assert headers["Authorization"] == "Bearer static-token-12345"
                 assert headers["Content-Type"] == "application/json-patch+json"
@@ -256,7 +258,8 @@ class TestBearerTokenCommandIntegration:
                 tool = AzureWorkItemTool(command_executor=mock_executor)
 
                 # Get auth headers should use dynamic token from command
-                headers = tool._get_auth_headers()
+                from plugins.azrepo.azure_rest_utils import get_auth_headers
+                headers = get_auth_headers(content_type="application/json-patch+json")
 
                 assert headers["Authorization"] == "Bearer dynamic-token-from-command"
 

--- a/plugins/azrepo/tests/test_pull_requests.py
+++ b/plugins/azrepo/tests/test_pull_requests.py
@@ -133,7 +133,7 @@ class TestListPullRequestsAPI:
     ):
         """Test basic pull request listing via REST API with new defaults."""
         mock_auth_headers.return_value = {"Authorization": "Bearer fake-token"}
-        
+
         # Mock successful identity resolution
         from plugins.azrepo.azure_rest_utils import IdentityInfo
         mock_resolve_identity.return_value = IdentityInfo(
@@ -151,8 +151,8 @@ class TestListPullRequestsAPI:
         azure_pr_tool.default_repository = "test-repo"
         azure_pr_tool.default_target_branch = "main"
 
-        with patch.object(
-            azure_pr_tool, "_get_current_username", return_value="testuser"
+        with patch(
+            "plugins.azrepo.pr_tool.get_current_username", return_value="testuser"
         ):
             with mock_pr_azure_http_client(method="get", response_data={"value": mock_pr_list_response["data"]}) as mock_client:
                 result = await azure_pr_tool.list_pull_requests()
@@ -174,7 +174,7 @@ class TestListPullRequestsAPI:
 
                 assert result["success"] is True
                 assert "id,creator,date,title,source_ref,target_ref" in result["data"]
-                
+
                 # Verify identity resolution was called
                 mock_resolve_identity.assert_called_once_with("testuser", "test-org", "test-project")
 
@@ -270,13 +270,13 @@ class TestListPullRequestsAPI:
         azure_pr_tool.default_repository = "test-repo"
         azure_pr_tool.default_target_branch = "main"
 
-        with patch.object(
-            azure_pr_tool, "_get_current_username", return_value="testuser"
+        with patch(
+            "plugins.azrepo.pr_tool.get_current_username", return_value="testuser"
         ):
             # Mock identity resolution to fail (no bearer token configured)
             with patch("plugins.azrepo.pr_tool.resolve_identity") as mock_resolve:
                 mock_resolve.side_effect = Exception("Bearer token not configured")
-                
+
                 with mock_pr_azure_http_client(method="get", response_data={"value": mock_prs}) as mock_client:
                     result = await azure_pr_tool.list_pull_requests()
 
@@ -324,13 +324,13 @@ class TestListPullRequestsAPI:
         azure_pr_tool.default_repository = "test-repo"
         azure_pr_tool.default_target_branch = "main"
 
-        with patch.object(
-            azure_pr_tool, "_get_current_username", return_value="testuser"
+        with patch(
+            "plugins.azrepo.pr_tool.get_current_username", return_value="testuser"
         ):
             # Mock identity resolution to fail (no bearer token configured)
             with patch("plugins.azrepo.pr_tool.resolve_identity") as mock_resolve:
                 mock_resolve.side_effect = Exception("Bearer token not configured")
-                
+
                 with mock_pr_azure_http_client(method="get", response_data={"value": mock_prs}) as mock_client:
                     result = await azure_pr_tool.list_pull_requests(exclude_drafts=False)
 
@@ -353,8 +353,8 @@ class TestListPullRequestsAPI:
         azure_pr_tool.default_project = "test-project"
         azure_pr_tool.default_repository = "test-repo"
 
-        with patch.object(
-            azure_pr_tool, "_get_current_username", return_value="test.user@company.com"
+        with patch(
+            "plugins.azrepo.pr_tool.get_current_username", return_value="test.user@company.com"
         ):
             with mock_pr_azure_http_client(method="get", response_data={"value": mock_pr_list_response["data"]}) as mock_client:
                 # Explicitly pass None values to get old behavior
@@ -389,8 +389,8 @@ class TestListPullRequestsAPI:
         azure_pr_tool.default_repository = "test-repo"
         azure_pr_tool.default_target_branch = "develop"  # Custom default
 
-        with patch.object(
-            azure_pr_tool, "_get_current_username", return_value="test.user@company.com"
+        with patch(
+            "plugins.azrepo.pr_tool.get_current_username", return_value="test.user@company.com"
         ):
             with mock_pr_azure_http_client(method="get", response_data={"value": mock_pr_list_response["data"]}) as mock_client:
                 result = await azure_pr_tool.list_pull_requests()
@@ -547,8 +547,8 @@ class TestCreatePullRequest:
         azure_pr_tool.default_repository = "test-repo"
         azure_pr_tool.default_target_branch = "main"
 
-        with patch.object(
-            azure_pr_tool, "_get_current_username", return_value="test-user"
+        with patch(
+            "plugins.azrepo.pr_tool.get_current_username", return_value="test-user"
         ):
             # Mock the AzureHttpClient to handle both calls
             with patch("plugins.azrepo.pr_tool.AzureHttpClient") as mock_client_class:
@@ -636,7 +636,7 @@ class TestUpdatePullRequest:
 
     @pytest.mark.asyncio
     @patch("plugins.azrepo.pr_tool.get_auth_headers")
-    @patch("plugins.azrepo.pr_tool.AzurePullRequestTool._get_current_username")
+    @patch("plugins.azrepo.pr_tool.get_current_username")
     async def test_update_pull_request_with_flags(
         self, mock_username, mock_auth_headers, azure_pr_tool
     ):

--- a/plugins/azrepo/workitem_tool.py
+++ b/plugins/azrepo/workitem_tool.py
@@ -730,25 +730,3 @@ class AzureWorkItemTool(ToolInterface):
             )
         else:
             return {"success": False, "error": f"Unknown operation: {operation}"}
-
-    # Backward compatibility methods for tests
-    def _get_current_username(self) -> Optional[str]:
-        """Backward compatibility method for tests."""
-        return get_current_username()
-
-    def _get_auth_headers(self, content_type: str = "application/json-patch+json") -> Dict[str, str]:
-        """Backward compatibility method for tests."""
-        # If tests are using instance bearer_token, we need to inject it into the azrepo_params
-        # that get_auth_headers will request from env_manager
-        if self.bearer_token:
-            # Patch env_manager to include our bearer token
-            with patch("plugins.azrepo.azure_rest_utils.env_manager") as mock_env_manager:
-                # Get real parameters first
-                real_params = env_manager.get_azrepo_parameters()
-                # Add our bearer token
-                params = {**real_params, "bearer_token": self.bearer_token}
-                mock_env_manager.get_azrepo_parameters.return_value = params
-                return get_auth_headers(content_type=content_type)
-        else:
-            # Normal flow
-            return get_auth_headers(content_type=content_type)


### PR DESCRIPTION
…etrieval

This commit removes the backward compatibility methods `_get_current_username()` and `_get_auth_headers()` from both `AzurePullRequestTool` and `AzureWorkItemTool`. The code now directly calls the shared utility functions `get_current_username()` and `get_auth_headers()`, resulting in cleaner and more maintainable code. Additionally, tests have been updated to mock the shared utilities directly, ensuring consistency across the codebase.