### PR TITLE
Integrate Neo4j Graph Interface Tests into Test Runner

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -209,6 +209,7 @@ if [[ "$PARALLEL_MODE" == "--parallel" || "$PARALLEL_MODE" == "-p" ]]; then
         "utils.secret_scanner:utils/secret_scanner/tests"
         "utils.ocr_extractor:utils/ocr_extractor/tests"
         "utils.playwright:utils/playwright/tests"
+        "utils.graph_interface:utils/graph_interface/tests"
         "plugins.azrepo:plugins/azrepo/tests"
         "plugins.kusto:plugins/kusto/tests"
         "plugins.git_tool:plugins/git_tool/tests"
@@ -285,6 +286,7 @@ else
     run_component_tests "utils.secret_scanner" "utils/secret_scanner/tests" "$TEST_PATTERN"
     run_component_tests "utils.ocr_extractor" "utils/ocr_extractor/tests" "$TEST_PATTERN"
     run_component_tests "utils.playwright" "utils/playwright/tests" "$TEST_PATTERN"
+    run_component_tests "utils.graph_interface" "utils/graph_interface/tests" "$TEST_PATTERN"
 
     # Run tests for plugins
     run_component_tests "plugins.azrepo" "plugins/azrepo/tests" "$TEST_PATTERN"

--- a/utils/graph_interface/tests/test_config.py
+++ b/utils/graph_interface/tests/test_config.py
@@ -141,31 +141,34 @@ neo4j:
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
             f.write(yaml_content)
             f.flush()
+            temp_file_path = f.name
 
-            try:
-                config = Neo4jConfig.from_yaml_file(Path(f.name))
-                assert config.connection.uri == "bolt://test:7687"
-                assert config.connection.username == "testuser"
-                assert config.pool.max_connections == 100
-            finally:
-                os.unlink(f.name)
+        try:
+            config = Neo4jConfig.from_yaml_file(Path(temp_file_path))
+            assert config.connection.uri == "bolt://test:7687"
+            assert config.connection.username == "testuser"
+            assert config.pool.max_connections == 100
+        finally:
+            os.unlink(temp_file_path)
 
     def test_to_yaml_file(self):
         """Test saving config to YAML file."""
         config = Neo4jConfig()
 
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-            try:
-                config.to_yaml_file(Path(f.name))
+            temp_file_path = f.name
 
-                # Verify file was created and contains expected content
-                with open(f.name, 'r') as read_f:
-                    content = read_f.read()
-                    assert 'neo4j:' in content
-                    assert 'connection:' in content
-                    assert 'pool:' in content
-            finally:
-                os.unlink(f.name)
+        try:
+            config.to_yaml_file(Path(temp_file_path))
+
+            # Verify file was created and contains expected content
+            with open(temp_file_path, 'r') as read_f:
+                content = read_f.read()
+                assert 'neo4j:' in content
+                assert 'connection:' in content
+                assert 'pool:' in content
+        finally:
+            os.unlink(temp_file_path)
 
 
 class TestConfigLoader:


### PR DESCRIPTION
## Summary
This PR integrates the Neo4j graph interface tests into the main test runner script (`scripts/run_tests.sh`).

## Changes Made
- Added `utils.graph_interface:utils/graph_interface/tests` to the parallel test execution components
- Added `utils.graph_interface` test execution to the sequential test mode
- Ensures all 34 Neo4j graph interface tests are properly included in the CI/CD pipeline

## Testing
- ✅ Verified that `./scripts/run_tests.sh "graph_interface" --parallel 2` correctly finds and runs all 34 tests
- ✅ All tests pass successfully (34 passed, 0 failed)
- ✅ Tests are properly integrated into both parallel and sequential execution modes

## Context
This completes the integration of the Neo4j Graph Interface Core Infrastructure (Issue #273) into the main test suite, ensuring that the graph interface tests are automatically executed as part of the project's testing workflow.

## Related Issues
- Completes integration for Issue #273: Neo4j Graph Interface Core Infrastructure