### PR TITLE
Add Docker server test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,3 +110,33 @@ jobs:
           # Clean up any remaining temporary test files
           Get-ChildItem -Path $env:TEMP -Filter "*test_chroma*" -Directory -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
           Get-ChildItem -Path $env:TEMP -Filter "*pytest*" -Directory -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+
+  docker-test:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build Docker image
+        run: docker build -t mcp-test-image .
+
+      - name: Start container
+        run: docker run -d --rm -p 8000:8000 --name mcp-test mcp-test-image
+
+      - name: Wait for server
+        run: |
+          for i in {1..30}; do
+            if curl -sSf http://localhost:8000/ > /dev/null; then
+              echo "Server ready" && exit 0
+            fi
+            sleep 2
+          done
+          echo "Server failed to start" && docker logs mcp-test && exit 1
+
+      - name: Verify HTTP endpoint
+        run: curl -sSf http://localhost:8000/
+
+      - name: Stop container
+        if: always()
+        run: docker stop mcp-test
+


### PR DESCRIPTION
## Summary
- add Docker server integration test
- update CI workflow to run Docker test on Ubuntu

## Testing
- `pytest server/tests/test_server_launch.py::TestServerLaunch::test_server_responds_to_http_requests -vv` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_684ba6708668832fb9e14ce79ce6f9f6