### PR TITLE
Codex: add category field to YAML tools

### DIFF
--- a/mcp_tools/tests/test_yaml_tool_base.py
+++ b/mcp_tools/tests/test_yaml_tool_base.py
@@ -253,6 +253,18 @@ class TestYamlToolBaseProperties:
         assert tool.input_schema["type"] == "object"
         assert "param" in tool.input_schema["properties"]
 
+    def test_category_property(self, sample_tool_data):
+        """Test the category property getter."""
+        tool_data = dict(sample_tool_data)
+        tool_data["category"] = "testing"
+        tool = YamlToolBase(tool_name="test_tool", tool_data=tool_data)
+        assert tool.category == "testing"
+
+    def test_category_property_default(self):
+        """Test default category when not provided."""
+        tool = YamlToolBase(tool_name="test_tool", tool_data={})
+        assert tool.category == "uncategorized"
+
 
 class TestYamlToolBaseToolTypeHandling:
     """Test cases for tool type handling."""

--- a/mcp_tools/yaml_tools.py
+++ b/mcp_tools/yaml_tools.py
@@ -61,6 +61,7 @@ class YamlToolBase(ToolInterface):
         )
         self._tool_data = tool_data
         self._tool_type = tool_data.get("type", "object")
+        self._category = tool_data.get("category", "uncategorized")
 
         # Get command executor from injector if not provided
         if command_executor is None:
@@ -84,6 +85,11 @@ class YamlToolBase(ToolInterface):
     def description(self) -> str:
         """Get the tool description."""
         return self._description
+
+    @property
+    def category(self) -> str:
+        """Get the tool category."""
+        return self._category
 
     @property
     def input_schema(self) -> Dict[str, Any]:
@@ -847,6 +853,9 @@ def load_yaml_tools() -> List[Type[ToolInterface]]:
         for name, tool_data in tools_data.items():
             try:
                 logger.debug(f"Processing YAML tool: {name}")
+
+                # Ensure category field is present
+                tool_data.setdefault("category", "uncategorized")
 
                 # Skip disabled tools
                 if tool_data.get("enabled", True) == False:

--- a/server/api/tools.py
+++ b/server/api/tools.py
@@ -19,6 +19,7 @@ async def api_list_tools(request: Request) -> JSONResponse:
         input_schema: Dict[str, Any] = (
             instance.input_schema if instance else {}
         )
+        category = getattr(instance, "category", "uncategorized")
         tools.append(
             {
                 "name": name,
@@ -26,6 +27,7 @@ async def api_list_tools(request: Request) -> JSONResponse:
                 "active": name in active_instances,
                 "description": description,
                 "input_schema": input_schema,
+                "category": category,
             }
         )
     return JSONResponse({"tools": tools, "total": len(tools), "active": len(active_instances)})
@@ -42,6 +44,7 @@ async def api_get_tool_detail(request: Request) -> JSONResponse:
             "name": tool_name,
             "description": instance.description,
             "input_schema": instance.input_schema,
+            "category": getattr(instance, "category", "uncategorized"),
             "source": tool_sources.get(tool_name, "unknown"),
             "active": tool_name in injector.get_filtered_instances(),
         }

--- a/server/tools.yaml
+++ b/server/tools.yaml
@@ -2,6 +2,7 @@ tools:
   execute_command_async:
     enabled: false
     name: execute_command_async
+    category: command
     description: |
       Start a command execution asynchronously and return a token for tracking.
       Use the token to query the status (tool/query_command_status) of the command execution every 30 seconds.
@@ -20,6 +21,7 @@ tools:
   query_command_status:
     enabled: false
     name: query_command_status
+    category: command
     description: Query the status of an asynchronous command execution or wait for it to complete
     inputSchema:
       type: object
@@ -40,6 +42,7 @@ tools:
   execute_task:
     enabled: true
     name: execute_task
+    category: task
     description: |
       Execute a predefined task by name and start it asynchronously.
       Use the token returned by this tool to query the status (tool/query_task_status) of the task execution every 30 seconds.
@@ -55,6 +58,7 @@ tools:
   query_task_status:
     enabled: true
     name: query_task_status
+    category: task
     description: Query the status of an asynchronously executed task
     inputSchema:
       type: object
@@ -68,6 +72,7 @@ tools:
   list_tasks:
     enabled: true
     name: list_tasks
+    category: task
     description: List all available predefined tasks
     inputSchema:
       type: object
@@ -77,6 +82,7 @@ tools:
   list_instructions:
     enabled: true
     name: list_instructions
+    category: instruction
     description: List all available instructions
     inputSchema:
       type: object
@@ -86,6 +92,7 @@ tools:
   get_instruction:
     enabled: true
     name: get_instruction
+    category: instruction
     description: Get a specific instruction with its details
     inputSchema:
       type: object
@@ -99,6 +106,7 @@ tools:
   query_script_status:
     enabled: true
     name: query_script_status
+    category: script
     description: Query the status of an asynchronously executed script
     inputSchema:
       type: object
@@ -116,6 +124,7 @@ tools:
   deploy:
     enabled: true
     name: deploy
+    category: deployment
     description: |
       Deploy the application asynchronously and return a token for tracking.
       Use the token to query the status (tool/query_script_status).
@@ -165,6 +174,7 @@ tools:
   health_check:
     enabled: true
     name: health_check
+    category: monitoring
     description: |
       Check application health status without verbose curl output.
       Use the token to query the status (tool/query_script_status).
@@ -188,6 +198,7 @@ tools:
   validate_config:
     enabled: true
     name: validate_config
+    category: validation
     description: |
       Validate configuration files and show only validation errors.
       Use the token to query the status (tool/query_script_status).


### PR DESCRIPTION
## Summary
- support optional `category` field for YAML tools
- include category details in API responses
- document categories in `tools.yaml`
- add category property tests

Fixes #174

------
https://chatgpt.com/codex/tasks/task_e_684fc0907b948322b28c6c9a0a9a0e29