### PR TITLE
Enhance OS compatibility check in PluginConfig class

### DIFF
--- a/mcp_tools/plugin_config.py
+++ b/mcp_tools/plugin_config.py
@@ -340,6 +340,10 @@ class PluginConfig:
 
         os_lower = os.lower()
 
+        # Tools with os_type="all" should always be compatible
+        if os_lower == "all":
+            return True
+
         # If enabled_os is empty, all OS types are enabled
         if not self.enabled_os:
             return True

--- a/mcp_tools/tests/test_plugin_config.py
+++ b/mcp_tools/tests/test_plugin_config.py
@@ -615,7 +615,7 @@ def test_os_config_default(monkeypatch):
     assert cfg.enabled_os == {"non-windows"}
     assert not cfg.is_os_enabled("windows")
     assert cfg.is_os_enabled("non-windows")
-    assert not cfg.is_os_enabled("all")
+    assert cfg.is_os_enabled("all")  # Tools with os_type="all" are always compatible
     assert cfg.is_os_enabled(None)  # None is always enabled for backward compatibility
 
 
@@ -636,7 +636,7 @@ def test_os_config_specific_os(monkeypatch):
     assert cfg.enabled_os == {"windows", "non-windows"}
     assert cfg.is_os_enabled("windows")
     assert cfg.is_os_enabled("non-windows")
-    assert not cfg.is_os_enabled("all")
+    assert cfg.is_os_enabled("all")  # Tools with os_type="all" are always compatible
 
 
 def test_os_config_single_os(monkeypatch):
@@ -646,7 +646,7 @@ def test_os_config_single_os(monkeypatch):
     assert cfg.enabled_os == {"windows"}
     assert cfg.is_os_enabled("windows")
     assert not cfg.is_os_enabled("non-windows")
-    assert not cfg.is_os_enabled("all")
+    assert cfg.is_os_enabled("all")  # Tools with os_type="all" are always compatible
 
 
 def test_os_config_case_insensitive(monkeypatch):


### PR DESCRIPTION
Added support for tools with os_type=all to always return compatible in the is_os_enabled method. Updated corresponding test cases to reflect this change.