### PR TITLE
Codex: add enum constants for ecosystem and OS

### DIFF
--- a/mcp_tools/__init__.py
+++ b/mcp_tools/__init__.py
@@ -28,6 +28,7 @@ from mcp_tools.plugin import (
     discover_and_register_tools,
     PluginRegistry,
 )
+from mcp_tools.constants import Ecosystem, OSType
 
 # Import dependency injection system
 from mcp_tools.dependency import injector, DependencyInjector
@@ -59,4 +60,6 @@ __all__ = [
     # YAML tools
     "YamlToolBase",
     "discover_and_register_yaml_tools",
+    "Ecosystem",
+    "OSType",
 ]

--- a/mcp_tools/browser/browser_client.py
+++ b/mcp_tools/browser/browser_client.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, Optional, Literal
 from mcp_tools.browser.factory import BrowserClientFactory
 from mcp_tools.plugin import register_tool
 from mcp_tools.interfaces import BrowserClientInterface
+from mcp_tools.constants import OSType
 from config import env
 from utils.html_to_markdown import extract_and_format_html
 from utils.secret_scanner import redact_secrets
@@ -43,7 +44,7 @@ def _get_domain_from_url(url: str) -> str:
         return "unknown domain"
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class BrowserClient(BrowserClientInterface):
     """Client for browser automation operations.
 

--- a/mcp_tools/browser/capture_panels_client.py
+++ b/mcp_tools/browser/capture_panels_client.py
@@ -6,6 +6,7 @@ from typing import Dict, Any, Optional, Literal
 from mcp_tools.browser.factory import BrowserClientFactory
 from mcp_tools.plugin import register_tool
 from mcp_tools.interfaces import CapturePanelsClientInterface
+from mcp_tools.constants import OSType
 from config import env
 
 DEFAULT_BROWSER_TYPE: Literal["chrome", "edge"] = env.get_setting(
@@ -14,7 +15,7 @@ DEFAULT_BROWSER_TYPE: Literal["chrome", "edge"] = env.get_setting(
 DEFAULT_CLIENT_TYPE: str = env.get_setting("client_type", "playwright")
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class CapturePanelsClient(CapturePanelsClientInterface):
     """Dedicated client for capturing dashboard panels as PNGs."""
 

--- a/mcp_tools/command_executor/tmux_executor.py
+++ b/mcp_tools/command_executor/tmux_executor.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, Optional
 
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import OSType
 
 
 def _has_tmux() -> bool:
@@ -11,7 +12,7 @@ def _has_tmux() -> bool:
     return shutil.which("tmux") is not None
 
 
-@register_tool(os_type="non-windows")
+@register_tool(os_type=OSType.NON_WINDOWS)
 class TmuxExecutor(ToolInterface):
     """Execute commands inside a tmux session using ``send-keys``."""
 

--- a/mcp_tools/constants.py
+++ b/mcp_tools/constants.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+class Ecosystem(Enum):
+    MICROSOFT = "microsoft"
+    GENERAL = "general"
+
+    def __str__(self) -> str:
+        return self.value
+
+class OSType(Enum):
+    WINDOWS = "windows"
+    NON_WINDOWS = "non-windows"
+    ALL = "all"
+
+    def __str__(self) -> str:
+        return self.value

--- a/mcp_tools/plugin_config.py
+++ b/mcp_tools/plugin_config.py
@@ -7,8 +7,10 @@ allowing customization of tool discovery and registration behavior.
 import os
 import platform
 import logging
-from typing import List, Dict, Any, Set, Optional
+from typing import List, Dict, Any, Set, Optional, Union
 from pathlib import Path
+
+from mcp_tools.constants import Ecosystem, OSType
 
 logger = logging.getLogger(__name__)
 
@@ -221,8 +223,12 @@ class PluginConfig:
             return "*"
 
     def should_register_tool_class(
-        self, class_name: str, tool_name: str, yaml_tools: Set[str],
-        ecosystem: Optional[str] = None, os_type: Optional[str] = None
+        self,
+        class_name: str,
+        tool_name: str,
+        yaml_tools: Set[str],
+        ecosystem: Optional[Union[str, Ecosystem]] = None,
+        os_type: Optional[Union[str, OSType]] = None,
     ) -> bool:
         """Determine if a tool class should be registered.
 
@@ -303,7 +309,7 @@ class PluginConfig:
             logger.warning(f"Unknown plugin enable mode: {self.plugin_enable_mode}")
             return True
 
-    def is_ecosystem_enabled(self, ecosystem: Optional[str]) -> bool:
+    def is_ecosystem_enabled(self, ecosystem: Optional[Union[str, Ecosystem]]) -> bool:
         """Check if an ecosystem is enabled based on the current configuration.
 
         Args:
@@ -316,7 +322,7 @@ class PluginConfig:
         if ecosystem is None:
             return True
 
-        ecosystem_lower = ecosystem.lower()
+        ecosystem_lower = str(ecosystem).lower()
 
         # If enabled_ecosystems is empty, all ecosystems are enabled
         if not self.enabled_ecosystems:
@@ -325,7 +331,7 @@ class PluginConfig:
         # Otherwise, only explicitly enabled ecosystems are allowed
         return ecosystem_lower in self.enabled_ecosystems
 
-    def is_os_enabled(self, os: Optional[str]) -> bool:
+    def is_os_enabled(self, os: Optional[Union[str, OSType]]) -> bool:
         """Check if an OS is enabled based on the current configuration.
 
         Args:
@@ -338,7 +344,7 @@ class PluginConfig:
         if os is None:
             return True
 
-        os_lower = os.lower()
+        os_lower = str(os).lower()
 
         # Tools with os_type="all" should always be compatible
         if os_lower == "all":
@@ -373,44 +379,44 @@ class PluginConfig:
         self.enabled_plugins.discard(plugin_name)
         logger.info(f"Plugin '{plugin_name}' has been disabled")
 
-    def enable_ecosystem(self, ecosystem: str) -> None:
+    def enable_ecosystem(self, ecosystem: Union[str, Ecosystem]) -> None:
         """Enable a specific ecosystem.
 
         Args:
             ecosystem: Name of the ecosystem to enable
         """
-        ecosystem_lower = ecosystem.lower()
+        ecosystem_lower = str(ecosystem).lower()
         self.enabled_ecosystems.add(ecosystem_lower)
         logger.info(f"Ecosystem '{ecosystem}' has been enabled")
 
-    def disable_ecosystem(self, ecosystem: str) -> None:
+    def disable_ecosystem(self, ecosystem: Union[str, Ecosystem]) -> None:
         """Disable a specific ecosystem.
 
         Args:
             ecosystem: Name of the ecosystem to disable
         """
-        ecosystem_lower = ecosystem.lower()
+        ecosystem_lower = str(ecosystem).lower()
         # Remove from enabled set (disabling means not in the enabled set)
         self.enabled_ecosystems.discard(ecosystem_lower)
         logger.info(f"Ecosystem '{ecosystem}' has been disabled")
 
-    def enable_os(self, os: str) -> None:
+    def enable_os(self, os: Union[str, OSType]) -> None:
         """Enable a specific OS.
 
         Args:
             os: Name of the OS to enable
         """
-        os_lower = os.lower()
+        os_lower = str(os).lower()
         self.enabled_os.add(os_lower)
         logger.info(f"OS '{os}' has been enabled")
 
-    def disable_os(self, os: str) -> None:
+    def disable_os(self, os: Union[str, OSType]) -> None:
         """Disable a specific OS.
 
         Args:
             os: Name of the OS to disable
         """
-        os_lower = os.lower()
+        os_lower = str(os).lower()
         # Remove from enabled set (disabling means not in the enabled set)
         self.enabled_os.discard(os_lower)
         logger.info(f"OS '{os}' has been disabled")

--- a/mcp_tools/plugin_config.py
+++ b/mcp_tools/plugin_config.py
@@ -4,11 +4,11 @@ This module provides a configuration system for the plugin registry,
 allowing customization of tool discovery and registration behavior.
 """
 
+import logging
 import os
 import platform
-import logging
-from typing import List, Dict, Any, Set, Optional, Union
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Union
 
 from mcp_tools.constants import Ecosystem, OSType
 
@@ -16,7 +16,11 @@ logger = logging.getLogger(__name__)
 
 
 class PluginConfig:
-    """Configuration for the plugin system."""
+    """Configuration for the plugin system.
+
+    This class supports filtering tools by ecosystem and operating system using
+    either plain strings or the :class:`Ecosystem` and :class:`OSType` enums.
+    """
 
     def __init__(self):
         """Initialize plugin configuration with default values."""
@@ -142,14 +146,18 @@ class PluginConfig:
         if env_plugin_mode in ("all", "whitelist", "blacklist"):
             self.plugin_enable_mode = env_plugin_mode
         else:
-            logger.warning(f"Invalid MCP_PLUGIN_MODE value: {env_plugin_mode}. Using 'all'")
+            logger.warning(
+                f"Invalid MCP_PLUGIN_MODE value: {env_plugin_mode}. Using 'all'"
+            )
             self.plugin_enable_mode = "all"
 
         # Get enabled plugins
         env_enabled_plugins = os.environ.get("MCP_ENABLED_PLUGINS", "")
         if env_enabled_plugins:
             enabled_plugins = {
-                plugin.strip() for plugin in env_enabled_plugins.split(",") if plugin.strip()
+                plugin.strip()
+                for plugin in env_enabled_plugins.split(",")
+                if plugin.strip()
             }
             self.enabled_plugins.update(enabled_plugins)
             logger.info(f"Enabled plugins from environment: {self.enabled_plugins}")
@@ -158,7 +166,9 @@ class PluginConfig:
         env_disabled_plugins = os.environ.get("MCP_DISABLED_PLUGINS", "")
         if env_disabled_plugins:
             disabled_plugins = {
-                plugin.strip() for plugin in env_disabled_plugins.split(",") if plugin.strip()
+                plugin.strip()
+                for plugin in env_disabled_plugins.split(",")
+                if plugin.strip()
             }
             self.disabled_plugins.update(disabled_plugins)
             logger.info(f"Disabled plugins from environment: {self.disabled_plugins}")
@@ -175,10 +185,14 @@ class PluginConfig:
         else:
             # Parse comma-separated list
             enabled_ecosystems = {
-                ecosystem.strip().lower() for ecosystem in env_ecosystems.split(",") if ecosystem.strip()
+                ecosystem.strip().lower()
+                for ecosystem in env_ecosystems.split(",")
+                if ecosystem.strip()
             }
             self.enabled_ecosystems = enabled_ecosystems
-            logger.info(f"Enabled ecosystems from environment: {self.enabled_ecosystems}")
+            logger.info(
+                f"Enabled ecosystems from environment: {self.enabled_ecosystems}"
+            )
 
     def _load_os_config_from_env(self):
         """Load OS configuration from environment variables with auto-detection."""
@@ -198,7 +212,9 @@ class PluginConfig:
         else:
             # Parse comma-separated list
             enabled_os = {
-                os_type.strip().lower() for os_type in env_os.split(",") if os_type.strip()
+                os_type.strip().lower()
+                for os_type in env_os.split(",")
+                if os_type.strip()
             }
             self.enabled_os = enabled_os
             logger.info(f"Enabled OS types: {self.enabled_os}")
@@ -236,8 +252,10 @@ class PluginConfig:
             class_name: Name of the class
             tool_name: Name of the tool
             yaml_tools: Set of tool names defined in YAML
-            ecosystem: Ecosystem the tool belongs to (e.g., "microsoft", "general")
-            os_type: OS compatibility ("windows", "non-windows", "all")
+            ecosystem: Ecosystem the tool belongs to. Can be a string or
+                :class:`Ecosystem` enum value.
+            os_type: OS compatibility. Can be a string or
+                :class:`OSType` enum value.
 
         Returns:
             True if the tool should be registered, False otherwise
@@ -259,12 +277,16 @@ class PluginConfig:
 
         # Check ecosystem enable/disable status
         if not self.is_ecosystem_enabled(ecosystem):
-            logger.debug(f"Skipping registration of tool '{tool_name}' from disabled ecosystem: {ecosystem}")
+            logger.debug(
+                f"Skipping registration of tool '{tool_name}' from disabled ecosystem: {ecosystem}"
+            )
             return False
 
         # Check OS enable/disable status
         if not self.is_os_enabled(os_type):
-            logger.debug(f"Skipping registration of tool '{tool_name}' from disabled OS: {os_type}")
+            logger.debug(
+                f"Skipping registration of tool '{tool_name}' from disabled OS: {os_type}"
+            )
             return False
 
         # Check if there's a YAML definition that should override this
@@ -313,7 +335,8 @@ class PluginConfig:
         """Check if an ecosystem is enabled based on the current configuration.
 
         Args:
-            ecosystem: Name of the ecosystem to check (case-insensitive)
+            ecosystem: Name of the ecosystem to check. Accepts either a
+                string or :class:`Ecosystem` enum (case-insensitive).
 
         Returns:
             True if the ecosystem should be enabled, False otherwise
@@ -335,7 +358,8 @@ class PluginConfig:
         """Check if an OS is enabled based on the current configuration.
 
         Args:
-            os: Name of the OS to check (case-insensitive)
+            os: Name of the OS to check. Accepts either a string or
+                :class:`OSType` enum (case-insensitive).
 
         Returns:
             True if the OS should be enabled, False otherwise
@@ -383,7 +407,8 @@ class PluginConfig:
         """Enable a specific ecosystem.
 
         Args:
-            ecosystem: Name of the ecosystem to enable
+            ecosystem: The ecosystem to enable. Accepts a string or
+                :class:`Ecosystem` enum.
         """
         ecosystem_lower = str(ecosystem).lower()
         self.enabled_ecosystems.add(ecosystem_lower)
@@ -393,7 +418,8 @@ class PluginConfig:
         """Disable a specific ecosystem.
 
         Args:
-            ecosystem: Name of the ecosystem to disable
+            ecosystem: The ecosystem to disable. Accepts a string or
+                :class:`Ecosystem` enum.
         """
         ecosystem_lower = str(ecosystem).lower()
         # Remove from enabled set (disabling means not in the enabled set)
@@ -404,7 +430,8 @@ class PluginConfig:
         """Enable a specific OS.
 
         Args:
-            os: Name of the OS to enable
+            os: The OS type to enable. Accepts a string or
+                :class:`OSType` enum.
         """
         os_lower = str(os).lower()
         self.enabled_os.add(os_lower)
@@ -414,7 +441,8 @@ class PluginConfig:
         """Disable a specific OS.
 
         Args:
-            os: Name of the OS to disable
+            os: The OS type to disable. Accepts a string or
+                :class:`OSType` enum.
         """
         os_lower = str(os).lower()
         # Remove from enabled set (disabling means not in the enabled set)
@@ -431,6 +459,7 @@ class PluginConfig:
         try:
             # Import here to avoid circular imports
             from mcp_tools.plugin import registry
+
             return registry.get_available_plugins()
         except ImportError:
             # Fallback to basic information about configured plugins
@@ -446,7 +475,7 @@ class PluginConfig:
                     "source": "configuration",
                     "explicitly_configured": True,
                     "registered": False,
-                    "has_instance": False
+                    "has_instance": False,
                 }
 
             return available_plugins

--- a/mcp_tools/tests/test_plugin_config.py
+++ b/mcp_tools/tests/test_plugin_config.py
@@ -12,16 +12,24 @@ def reset_plugin_state():
     # Clear registry
     registry.clear()
 
-    # Reset config to default state
+    # Reset config to a clean state
     config.plugin_enable_mode = "all"
     config.enabled_plugins = set()
     config.disabled_plugins = set()
     config.excluded_tool_names = set()
+    config.enabled_ecosystems = set()
+    config.enabled_os = {config._detect_current_os()}
 
     yield
 
     # Clean up after test
     registry.clear()
+    config.plugin_enable_mode = "all"
+    config.enabled_plugins = set()
+    config.disabled_plugins = set()
+    config.excluded_tool_names = set()
+    config.enabled_ecosystems = set()
+    config.enabled_os = {config._detect_current_os()}
 
 class DummyTool(ToolInterface):
     """Simple tool for testing exclusion."""

--- a/mcp_tools/tests/test_plugin_config.py
+++ b/mcp_tools/tests/test_plugin_config.py
@@ -1005,6 +1005,22 @@ def test_os_auto_detection_integration_with_ecosystem_filtering(monkeypatch):
     )
 
 
+def test_enum_values_supported():
+    """Ecosystem and OS enums are accepted."""
+    from mcp_tools.constants import Ecosystem, OSType
+
+    cfg = PluginConfig()
+    assert cfg.is_ecosystem_enabled(Ecosystem.MICROSOFT)
+    assert cfg.is_os_enabled(OSType.ALL)
+    assert cfg.should_register_tool_class(
+        "EnumTool",
+        "enum_tool",
+        set(),
+        ecosystem=Ecosystem.GENERAL,
+        os_type=OSType.NON_WINDOWS,
+    )
+
+
 # OS Auto-Detection Tests
 
 def test_detect_current_os_windows(monkeypatch):

--- a/plugins/azrepo/pr_tool.py
+++ b/plugins/azrepo/pr_tool.py
@@ -12,6 +12,7 @@ import git
 # Import the required interfaces and decorators
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 
 # Import configuration manager
 from config import env_manager
@@ -74,7 +75,7 @@ except ImportError:
     PullRequestCommentResponse = types_module.PullRequestCommentResponse
 
 
-@register_tool(ecosystem="microsoft", os_type="all")
+@register_tool(ecosystem=Ecosystem.MICROSOFT, os_type=OSType.ALL)
 class AzurePullRequestTool(ToolInterface):
     """Dedicated tool for managing Azure DevOps Pull Requests using REST API.
 

--- a/plugins/azrepo/repo_tool.py
+++ b/plugins/azrepo/repo_tool.py
@@ -7,12 +7,13 @@ from typing import Dict, Any, List, Optional, Union
 # Import the required interfaces and decorators
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 
 # Import configuration manager
 from config import env_manager
 
 
-@register_tool(ecosystem="microsoft", os_type="all")
+@register_tool(ecosystem=Ecosystem.MICROSOFT, os_type=OSType.ALL)
 class AzureRepoClient(ToolInterface):
     """Client for interacting with Azure DevOps Repositories using Azure CLI commands.
 

--- a/plugins/azrepo/workitem_tool.py
+++ b/plugins/azrepo/workitem_tool.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 # Import the required interfaces and decorators
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 
 # Import configuration manager
 from config import env_manager
@@ -60,7 +61,7 @@ except ImportError:
 # Constants
 API_VERSION = "7.1"  # Azure DevOps API version
 
-@register_tool(ecosystem="microsoft", os_type="all")
+@register_tool(ecosystem=Ecosystem.MICROSOFT, os_type=OSType.ALL)
 class AzureWorkItemTool(ToolInterface):
     """Dedicated tool for managing Azure DevOps Work Items.
 

--- a/plugins/circleci/circleci_tool.py
+++ b/plugins/circleci/circleci_tool.py
@@ -5,9 +5,10 @@ import httpx
 
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 
 
-@register_tool(ecosystem="general", os_type="all")
+@register_tool(ecosystem=Ecosystem.GENERAL, os_type=OSType.ALL)
 class CircleCITool(ToolInterface):
     """Interact with the CircleCI REST API."""
 

--- a/plugins/git_tool/git_commit_tool.py
+++ b/plugins/git_tool/git_commit_tool.py
@@ -13,6 +13,7 @@ import git
 
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 
 
 class GitCommitOperationType(str, Enum):
@@ -22,7 +23,7 @@ class GitCommitOperationType(str, Enum):
     PULL_REBASE = "git_pull_rebase"
 
 
-@register_tool(ecosystem="general", os_type="all")
+@register_tool(ecosystem=Ecosystem.GENERAL, os_type=OSType.ALL)
 class GitCommitTool(ToolInterface):
     """Git commit tool for commit and pull rebase operations through MCP."""
 

--- a/plugins/git_tool/git_tool.py
+++ b/plugins/git_tool/git_tool.py
@@ -15,6 +15,7 @@ import git
 
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 
 
 class GitOperationType(str, Enum):
@@ -35,7 +36,7 @@ class GitOperationType(str, Enum):
     CHERRY_PICK = "git_cherry_pick"
 
 
-@register_tool(ecosystem="general", os_type="all")
+@register_tool(ecosystem=Ecosystem.GENERAL, os_type=OSType.ALL)
 class GitTool(ToolInterface):
     """Git tool for repository operations through MCP."""
 

--- a/plugins/knowledge_indexer/tool.py
+++ b/plugins/knowledge_indexer/tool.py
@@ -9,12 +9,13 @@ import datetime
 
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import OSType
 from utils.vector_store.markdown_segmenter import MarkdownSegmenter
 from utils.vector_store.vector_store import ChromaVectorStore
 from config import env
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class KnowledgeIndexerTool(ToolInterface):
     """Tool for users to upload and index new knowledge from files into a vector store."""
 
@@ -203,7 +204,7 @@ class KnowledgeIndexerTool(ToolInterface):
             return {"success": False, "error": f"Knowledge indexing failed: {str(e)}"}
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class KnowledgeQueryTool(ToolInterface):
     """Tool for language models to query and retrieve indexed knowledge from the vector store."""
 
@@ -288,7 +289,7 @@ class KnowledgeQueryTool(ToolInterface):
             return {"success": False, "error": f"Knowledge query failed: {str(e)}"}
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class KnowledgeCollectionManagerTool(ToolInterface):
     """Internal administrative tool for managing knowledge collections - not for general use."""
 

--- a/plugins/kusto/tool.py
+++ b/plugins/kusto/tool.py
@@ -17,10 +17,11 @@ from azure.identity import DefaultAzureCredential
 # Import the required interfaces and decorators
 from mcp_tools.interfaces import ToolInterface, KustoClientInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import Ecosystem, OSType
 from config import env
 
 
-@register_tool(ecosystem="microsoft", os_type="all")
+@register_tool(ecosystem=Ecosystem.MICROSOFT, os_type=OSType.ALL)
 class KustoClient(KustoClientInterface):
     """Client for interacting with Azure Data Explorer (Kusto).
 

--- a/plugins/text_summarizer/tool.py
+++ b/plugins/text_summarizer/tool.py
@@ -7,10 +7,11 @@ from typing import Dict, Any
 # Import the required interfaces and decorators
 from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
+from mcp_tools.constants import OSType
 from utils.html_to_markdown import extract_and_format_html
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class WebSummarizerTool(ToolInterface):
     """Tool for summarizing web content and converting it to markdown."""
 
@@ -67,7 +68,7 @@ class WebSummarizerTool(ToolInterface):
         )
 
 
-@register_tool(os_type="all")
+@register_tool(os_type=OSType.ALL)
 class UrlSummarizerTool(ToolInterface):
     """Tool for fetching a URL and extracting its content into markdown."""
 


### PR DESCRIPTION
## Summary
- introduce `Ecosystem` and `OSType` enums
- update plugin configuration and registry to accept enums
- expose constants in `mcp_tools.__init__`
- add test covering enum usage

## Testing
- `uv pip install -e .`
- `uv pip install pytest pytest-asyncio pytest-xdist`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6851e33cd1948322adc8fb92b9ebb7cd