### PR TITLE
Add runtime MCP admin plugin

### DIFF
--- a/plugins/.gitignore
+++ b/plugins/.gitignore
@@ -31,6 +31,10 @@
 !circleci/
 !circleci/**
 
+# Track the mcp_admin plugin
+!mcp_admin/
+!mcp_admin/**
+
 # Ignore Python bytecode files
 *.pyc
 __pycache__/

--- a/plugins/mcp_admin/README.md
+++ b/plugins/mcp_admin/README.md
@@ -1,0 +1,4 @@
+# MCP Admin Plugin
+
+This plugin exposes operations that allow you to enable or disable MCP plugins
+at runtime.

--- a/plugins/mcp_admin/__init__.py
+++ b/plugins/mcp_admin/__init__.py
@@ -1,0 +1,3 @@
+"""MCP administration plugin."""
+
+__all__ = ["McpAdminTool"]

--- a/plugins/mcp_admin/tool.py
+++ b/plugins/mcp_admin/tool.py
@@ -1,0 +1,56 @@
+from typing import Dict, Any
+
+from mcp_tools.interfaces import ToolInterface
+from mcp_tools.plugin import register_tool, discover_and_register_tools, registry
+from mcp_tools.plugin_config import config
+
+
+@register_tool(os_type="all")
+class McpAdminTool(ToolInterface):
+    """Tool for administering the running MCP instance."""
+
+    @property
+    def name(self) -> str:
+        return "mcp_admin"
+
+    @property
+    def description(self) -> str:
+        return "Inspect and manage MCP plugins at runtime."
+
+    @property
+    def input_schema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "enum": [
+                        "enable_plugin",
+                        "disable_plugin",
+                    ],
+                    "description": "Action to perform",
+                },
+                "plugin": {
+                    "type": "string",
+                    "description": "Target plugin name",
+                },
+            },
+            "required": ["operation", "plugin"],
+        }
+
+    async def execute_tool(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        operation = arguments.get("operation")
+        plugin = arguments.get("plugin")
+
+        if operation == "enable_plugin":
+            config.enable_plugin(plugin)
+            if plugin not in registry.tools:
+                discover_and_register_tools()
+            return {"success": True, "plugin": plugin, "enabled": True}
+        elif operation == "disable_plugin":
+            config.disable_plugin(plugin)
+            registry.tools.pop(plugin, None)
+            registry.instances.pop(plugin, None)
+            return {"success": True, "plugin": plugin, "enabled": False}
+
+        return {"success": False, "error": f"Unknown operation: {operation}"}


### PR DESCRIPTION
## Summary
- add new `mcp_admin` plugin for runtime management
- expose operations to enable and disable plugins
- track the plugin in `plugins/.gitignore`

## Testing
- `pytest -q` *(fails: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6852cbde3bec832fb3ee21a5dd80d7e7