### PR TITLE
fix: setup virtual environment in daily-version workflow

### DIFF
--- a/.github/workflows/daily-version.yml
+++ b/.github/workflows/daily-version.yml
@@ -18,10 +18,15 @@ jobs:
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
 
-      - name: Install python-semantic-release
-        run: uv pip install python-semantic-release
+      - name: Setup Python environment
+        run: |
+          uv venv
+          source .venv/bin/activate
+          uv pip install python-semantic-release
 
       - name: Run semantic-release (version bump if needed)
-        run: semantic-release version
+        run: |
+          source .venv/bin/activate
+          semantic-release version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
The daily-version GitHub Actions workflow was failing with:
```
Run uv pip install python-semantic-release
error: No virtual environment found; run `uv venv` to create an environment, or pass `--system` to install into a non-virtual environment
Error: Process completed with exit code 2.
```

## Solution
This PR fixes the workflow by properly setting up a Python virtual environment using `uv venv` instead of using the `--system` flag.

### Changes Made
- ✅ Create virtual environment with `uv venv`
- ✅ Activate the virtual environment in both setup and execution steps
- ✅ Install `python-semantic-release` into the virtual environment
- ✅ Run `semantic-release` within the activated virtual environment

### Benefits
- **Better isolation**: Follows Python best practices for dependency management
- **Cleaner CI**: Avoids potential conflicts with system packages
- **More reliable**: Ensures consistent environment across workflow runs
- **Future-proof**: Easier to add additional Python dependencies if needed

## Testing
- The workflow structure follows standard GitHub Actions patterns
- Virtual environment activation is properly handled in multi-line commands
- All existing functionality (semantic-release version bumping) is preserved