### PR TITLE
refactor: move concurrency manager to utils for reusability

### DIFF
--- a/mcp_tools/tests/test_concurrency_manager.py
+++ b/mcp_tools/tests/test_concurrency_manager.py
@@ -5,7 +5,7 @@ import threading
 import time as time_module
 from unittest.mock import patch
 
-from mcp_tools.concurrency_manager import (
+from utils.concurrency import (
     ConcurrencyManager,
     ConcurrencyConfig,
     OperationContext,
@@ -16,12 +16,12 @@ from mcp_tools.concurrency_manager import (
 
 class TestConcurrencyConfig:
     """Test ConcurrencyConfig functionality."""
-    
+
     def test_default_config(self):
         """Test default configuration values."""
         config = ConcurrencyConfig()
         assert config.max_concurrent == 1
-    
+
     def test_custom_config(self):
         """Test custom configuration."""
         config = ConcurrencyConfig(max_concurrent=3)
@@ -30,18 +30,18 @@ class TestConcurrencyConfig:
 
 class TestOperationContext:
     """Test OperationContext functionality."""
-    
+
     def test_basic_context(self):
         """Test basic operation context creation."""
         context = OperationContext(
             operation_id="test_op_123",
             operation_type="test_operation"
         )
-        
+
         assert context.operation_id == "test_op_123"
         assert context.operation_type == "test_operation"
         assert context.start_time is not None
-    
+
     def test_default_operation_type(self):
         """Test default operation type."""
         context = OperationContext(operation_id="test_op")
@@ -50,17 +50,17 @@ class TestOperationContext:
 
 class TestConcurrencyManager:
     """Test ConcurrencyManager functionality."""
-    
+
     @pytest.fixture
     def manager(self):
         """Create a fresh concurrency manager for each test."""
         return ConcurrencyManager()
-    
+
     @pytest.fixture
     def config(self):
         """Create a test configuration."""
         return ConcurrencyConfig(max_concurrent=2)
-    
+
     @pytest.fixture
     def context(self):
         """Create a test operation context."""
@@ -68,29 +68,29 @@ class TestConcurrencyManager:
             operation_id="test_op_123",
             operation_type="test_operation"
         )
-    
+
     def test_register_config(self, manager, config):
         """Test registering concurrency configuration."""
         manager.register_config("test_tool", config)
         assert "test_tool" in manager._configs
         assert manager._configs["test_tool"] == config
-    
+
     def test_can_start_operation_no_config(self, manager, context):
         """Test that operations are allowed when no config is registered."""
         result = manager.can_start_operation("unknown_tool", context)
         assert result["allowed"] is True
-    
+
     def test_can_start_operation_within_limit(self, manager, config, context):
         """Test that operations are allowed within the limit."""
         manager.register_config("test_tool", config)
-        
+
         result = manager.can_start_operation("test_tool", context)
         assert result["allowed"] is True
-    
+
     def test_can_start_operation_exceeds_limit(self, manager, config):
         """Test that operations are rejected when limit is exceeded."""
         manager.register_config("test_tool", config)
-        
+
         # Start operations up to the limit
         for i in range(config.max_concurrent):
             context = OperationContext(
@@ -99,7 +99,7 @@ class TestConcurrencyManager:
             )
             result = manager.start_operation("test_tool", context)
             assert result["success"] is True
-        
+
         # Next operation should be rejected
         context = OperationContext(
             operation_id="test_op_overflow",
@@ -110,39 +110,39 @@ class TestConcurrencyManager:
         assert result["error"] == "concurrency_limit_exceeded"
         assert result["current_operations"] == config.max_concurrent
         assert result["max_allowed"] == config.max_concurrent
-    
+
     def test_start_and_finish_operation(self, manager, config, context):
         """Test starting and finishing operations."""
         manager.register_config("test_tool", config)
-        
+
         # Start operation
         result = manager.start_operation("test_tool", context)
         assert result["success"] is True
-        
+
         # Check that operation is tracked
         active_ops = manager.get_active_operations("test_tool")
         assert active_ops["count"] == 1
-        
+
         # Finish operation
         result = manager.finish_operation(context.operation_id)
         assert result["success"] is True
-        
+
         # Check that operation is no longer tracked
         active_ops = manager.get_active_operations("test_tool")
         assert active_ops["count"] == 0
-    
+
     def test_finish_unknown_operation(self, manager):
         """Test finishing an unknown operation."""
         result = manager.finish_operation("unknown_op")
         assert result["success"] is False
         assert result["error"] == "operation_not_found"
-    
+
     def test_different_tools(self, manager):
         """Test that different tools are tracked separately."""
         config = ConcurrencyConfig(max_concurrent=1)
         manager.register_config("tool1", config)
         manager.register_config("tool2", config)
-        
+
         # Start operation for first tool
         context1 = OperationContext(
             operation_id="op1",
@@ -150,7 +150,7 @@ class TestConcurrencyManager:
         )
         result = manager.start_operation("tool1", context1)
         assert result["success"] is True
-        
+
         # Start operation for second tool (should be allowed)
         context2 = OperationContext(
             operation_id="op2",
@@ -158,7 +158,7 @@ class TestConcurrencyManager:
         )
         result = manager.start_operation("tool2", context2)
         assert result["success"] is True
-        
+
         # Start another operation for first tool (should be rejected)
         context3 = OperationContext(
             operation_id="op3",
@@ -166,11 +166,11 @@ class TestConcurrencyManager:
         )
         result = manager.start_operation("tool1", context3)
         assert result["success"] is False
-    
+
     def test_get_active_operations_all(self, manager, config):
         """Test getting all active operations."""
         manager.register_config("test_tool", config)
-        
+
         # Start some operations
         contexts = []
         for i in range(2):
@@ -180,23 +180,23 @@ class TestConcurrencyManager:
             )
             contexts.append(context)
             manager.start_operation("test_tool", context)
-        
+
         # Get all active operations
         active_ops = manager.get_active_operations()
         assert "test_tool" in active_ops
         assert active_ops["test_tool"]["count"] == 2
         assert len(active_ops["test_tool"]["operations"]) == 2
-    
+
     def test_get_active_operations_by_tool(self, manager, config):
         """Test getting active operations for a specific tool."""
         manager.register_config("test_tool", config)
-        
+
         context = OperationContext(
             operation_id="test_op",
             operation_type="test_operation"
         )
         manager.start_operation("test_tool", context)
-        
+
         # Get operations for specific tool
         active_ops = manager.get_active_operations("test_tool")
         assert active_ops["tool_name"] == "test_tool"
@@ -207,16 +207,16 @@ class TestConcurrencyManager:
 
 class TestConcurrencyManagerThreadSafety:
     """Test thread safety of the concurrency manager."""
-    
+
     def test_concurrent_operations(self):
         """Test concurrent access to the concurrency manager."""
         manager = ConcurrencyManager()
         config = ConcurrencyConfig(max_concurrent=3)
         manager.register_config("test_tool", config)
-        
+
         results = []
         errors = []
-        
+
         def start_operation(op_id):
             try:
                 context = OperationContext(
@@ -225,34 +225,34 @@ class TestConcurrencyManagerThreadSafety:
                 )
                 result = manager.start_operation("test_tool", context)
                 results.append((op_id, result))
-                
+
                 # Simulate some work
                 time_module.sleep(0.1)
-                
+
                 # Finish the operation
                 manager.finish_operation(context.operation_id)
             except Exception as e:
                 errors.append((op_id, str(e)))
-        
+
         # Start multiple threads
         threads = []
         for i in range(5):
             thread = threading.Thread(target=start_operation, args=(i,))
             threads.append(thread)
             thread.start()
-        
+
         # Wait for all threads to complete
         for thread in threads:
             thread.join()
-        
+
         # Check results
         assert len(errors) == 0, f"Unexpected errors: {errors}"
         assert len(results) == 5
-        
+
         # Some operations should succeed, some should fail due to concurrency limits
         successful = [r for r in results if r[1]["success"]]
         failed = [r for r in results if not r[1]["success"]]
-        
+
         # At least some should succeed and some should fail
         assert len(successful) >= 1
         assert len(failed) >= 1
@@ -260,7 +260,7 @@ class TestConcurrencyManagerThreadSafety:
 
 class TestParseConcurrencyConfig:
     """Test parsing concurrency configuration from YAML data."""
-    
+
     def test_parse_basic_config(self):
         """Test parsing basic configuration."""
         config_data = {
@@ -268,13 +268,13 @@ class TestParseConcurrencyConfig:
         }
         config = parse_concurrency_config(config_data)
         assert config.max_concurrent == 5
-    
+
     def test_parse_config_with_defaults(self):
         """Test parsing configuration with default values."""
         config_data = {}
         config = parse_concurrency_config(config_data)
         assert config.max_concurrent == 1
-    
+
     def test_parse_empty_config(self):
         """Test parsing empty configuration."""
         config = parse_concurrency_config({})
@@ -283,12 +283,12 @@ class TestParseConcurrencyConfig:
 
 class TestGlobalConcurrencyManager:
     """Test global concurrency manager instance."""
-    
+
     def test_get_global_instance(self):
         """Test getting the global concurrency manager instance."""
         manager1 = get_concurrency_manager()
         manager2 = get_concurrency_manager()
-        
+
         # Should return the same instance
         assert manager1 is manager2
-        assert isinstance(manager1, ConcurrencyManager) 
+        assert isinstance(manager1, ConcurrencyManager)

--- a/mcp_tools/yaml_tools.py
+++ b/mcp_tools/yaml_tools.py
@@ -16,7 +16,7 @@ from mcp_tools.plugin import register_tool, registry
 from mcp_tools.dependency import injector
 from utils.secret_scanner import redact_secrets
 from utils.output_processor import OutputLimiter
-from mcp_tools.concurrency_manager import get_concurrency_manager, parse_concurrency_config
+from utils.concurrency import get_concurrency_manager, parse_concurrency_config
 
 # Configuration
 DEFAULT_WAIT_FOR_QUERY = True  # Default wait for task
@@ -949,7 +949,7 @@ def load_yaml_tools() -> List[Type[ToolInterface]]:
                     yaml_tool_classes.append(tool_class)
                     successful_tools.append(name)
                     logger.info(f"Successfully registered YAML tool: {name}")
-                    
+
                     # Register concurrency configuration if present
                     concurrency_config = tool_data.get("concurrency")
                     if concurrency_config:

--- a/utils/concurrency/__init__.py
+++ b/utils/concurrency/__init__.py
@@ -1,0 +1,17 @@
+"""Concurrency management utilities."""
+
+from .manager import (
+    ConcurrencyConfig,
+    OperationContext,
+    ConcurrencyManager,
+    get_concurrency_manager,
+    parse_concurrency_config
+)
+
+__all__ = [
+    'ConcurrencyConfig',
+    'OperationContext',
+    'ConcurrencyManager',
+    'get_concurrency_manager',
+    'parse_concurrency_config'
+]

--- a/utils/concurrency/manager.py
+++ b/utils/concurrency/manager.py
@@ -26,7 +26,7 @@ class OperationContext:
     operation_id: str
     operation_type: str = "operation"
     start_time: Optional[float] = None
-    
+
     def __post_init__(self):
         if self.start_time is None:
             self.start_time = time_module.time()
@@ -34,16 +34,16 @@ class OperationContext:
 
 class ConcurrencyManager:
     """Manages concurrency limits for operations."""
-    
+
     def __init__(self):
         self._lock = threading.RLock()
         self._active_operations: Dict[str, Set[str]] = {}  # tool_name -> set of operation_ids
         self._operation_contexts: Dict[str, OperationContext] = {}  # operation_id -> context
         self._configs: Dict[str, ConcurrencyConfig] = {}  # tool_name -> config
-    
+
     def register_config(self, tool_name: str, config: ConcurrencyConfig) -> None:
         """Register concurrency configuration for a tool.
-        
+
         Args:
             tool_name: Name of the tool
             config: Concurrency configuration
@@ -51,14 +51,14 @@ class ConcurrencyManager:
         with self._lock:
             self._configs[tool_name] = config
             logger.debug(f"Registered concurrency config for tool '{tool_name}': {config}")
-    
+
     def can_start_operation(self, tool_name: str, context: OperationContext) -> Dict[str, Any]:
         """Check if an operation can start based on concurrency limits.
-        
+
         Args:
             tool_name: Name of the tool requesting the operation
             context: Operation context
-            
+
         Returns:
             Dictionary with 'allowed' boolean and optional error information
         """
@@ -67,11 +67,11 @@ class ConcurrencyManager:
             if not config:
                 # No concurrency config, allow operation
                 return {"allowed": True}
-            
+
             # Get current operations for this tool
             current_operations = self._active_operations.get(tool_name, set())
             current_count = len(current_operations)
-            
+
             if current_count >= config.max_concurrent:
                 return {
                     "allowed": False,
@@ -82,16 +82,16 @@ class ConcurrencyManager:
                     "max_allowed": config.max_concurrent,
                     "tool_name": tool_name
                 }
-            
+
             return {"allowed": True}
-    
+
     def start_operation(self, tool_name: str, context: OperationContext) -> Dict[str, Any]:
         """Start tracking an operation.
-        
+
         Args:
             tool_name: Name of the tool
             context: Operation context
-            
+
         Returns:
             Dictionary with success status and optional error information
         """
@@ -100,29 +100,29 @@ class ConcurrencyManager:
             check_result = self.can_start_operation(tool_name, context)
             if not check_result["allowed"]:
                 return {"success": False, **check_result}
-            
+
             config = self._configs.get(tool_name)
             if not config:
                 # No concurrency config, just track the operation
                 self._operation_contexts[context.operation_id] = context
                 return {"success": True}
-            
+
             # Add operation to tracking
             if tool_name not in self._active_operations:
                 self._active_operations[tool_name] = set()
-            
+
             self._active_operations[tool_name].add(context.operation_id)
             self._operation_contexts[context.operation_id] = context
-            
+
             logger.info(f"Started tracking operation '{context.operation_id}' for tool '{tool_name}'")
             return {"success": True}
-    
+
     def finish_operation(self, operation_id: str) -> Dict[str, Any]:
         """Stop tracking an operation.
-        
+
         Args:
             operation_id: ID of the operation to stop tracking
-            
+
         Returns:
             Dictionary with success status
         """
@@ -131,7 +131,7 @@ class ConcurrencyManager:
             if not context:
                 logger.warning(f"Attempted to finish unknown operation: {operation_id}")
                 return {"success": False, "error": "operation_not_found"}
-            
+
             # Find and remove from all tools
             for tool_name, operations in self._active_operations.items():
                 if operation_id in operations:
@@ -139,20 +139,20 @@ class ConcurrencyManager:
                     if not operations:  # Clean up empty sets
                         del self._active_operations[tool_name]
                     break
-            
+
             # Remove from contexts
             del self._operation_contexts[operation_id]
-            
+
             duration = time_module.time() - context.start_time
             logger.info(f"Finished tracking operation '{operation_id}' (duration: {duration:.2f}s)")
             return {"success": True}
-    
+
     def get_active_operations(self, tool_name: Optional[str] = None) -> Dict[str, Any]:
         """Get information about active operations.
-        
+
         Args:
             tool_name: Optional tool name to filter by
-            
+
         Returns:
             Dictionary with active operations information
         """
@@ -189,28 +189,28 @@ class ConcurrencyManager:
                         ]
                     }
                 return result
-    
+
     def cleanup_stale_operations(self, max_age_seconds: float = 3600) -> Dict[str, Any]:
         """Clean up operations that have been running for too long.
-        
+
         Args:
             max_age_seconds: Maximum age in seconds before considering an operation stale
-            
+
         Returns:
             Dictionary with cleanup statistics
         """
         with self._lock:
             current_time = time_module.time()
             stale_operations = []
-            
+
             for operation_id, context in self._operation_contexts.items():
                 if current_time - context.start_time > max_age_seconds:
                     stale_operations.append(operation_id)
-            
+
             # Remove stale operations
             for operation_id in stale_operations:
                 self.finish_operation(operation_id)
-            
+
             logger.info(f"Cleaned up {len(stale_operations)} stale operations")
             return {
                 "cleaned_count": len(stale_operations),
@@ -230,13 +230,13 @@ def get_concurrency_manager() -> ConcurrencyManager:
 
 def parse_concurrency_config(config_dict: Dict[str, Any]) -> ConcurrencyConfig:
     """Parse concurrency configuration from dictionary.
-    
+
     Args:
         config_dict: Dictionary containing concurrency configuration
-        
+
     Returns:
         ConcurrencyConfig instance
     """
     return ConcurrencyConfig(
         max_concurrent=config_dict.get("max_concurrent", 1)
-    ) 
+    )


### PR DESCRIPTION
- Move concurrency_manager.py from mcp_tools to utils/concurrency/
- Update import statements in yaml_tools.py and test files
- Add proper __init__.py file for the new utils.concurrency module
- All tests pass after the move, maintaining functionality

This change makes the concurrency manager available as a shared utility across different modules in the project.

🤖 Generated with [Claude Code](https://claude.ai/code)