### PR TITLE
fix: resolve daily version bump GitHub Actions permission issues

### DIFF
--- a/.github/workflows/daily-version.yml
+++ b/.github/workflows/daily-version.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Required for accessing git tags
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2024-06-22
+## [0.1.0] - 2024-06-22
 
 ### Added
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2024-06-22
+
+### Added
+- Initial release


### PR DESCRIPTION
- Add contents: write permission to release job
- Add explicit GITHUB_TOKEN to checkout action
- Create missing CHANGELOG.md file to prevent warnings

🤖 Generated with [Claude Code](https://claude.ai/code)