### PR TITLE
fix: restrict daily version bump to patch/minor only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,16 @@ dev = [
     "isort>=6.0.1",
     "mypy>=1.15.0",
 ]
+
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+upload_to_vcs_release = false
+build_command = false
+commit_message = "chore: release {version}"
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["feat", "fix", "perf", "refactor"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf", "refactor"]
+# Explicitly disable major version bumps by not including any major_tags


### PR DESCRIPTION
- Add semantic-release configuration to pyproject.toml
- Configure only feat commits to bump minor version
- Configure fix/perf/refactor commits to bump patch version
- Remove major version bump capability to prevent unexpected 0.1.0 → 1.0.0 jumps
- Ensures daily version bump workflow never touches major version

🤖 Generated with [Claude Code](https://claude.ai/code)