### PR TITLE
feat: add in-memory KV store tool with TTL support

### DIFF
--- a/mcp_tools/__init__.py
+++ b/mcp_tools/__init__.py
@@ -35,6 +35,9 @@ from mcp_tools.dependency import injector, DependencyInjector
 # Import YAML tools system
 from mcp_tools.yaml_tools import YamlToolBase, discover_and_register_yaml_tools
 
+# Import tools
+from mcp_tools.kv_store import KVStoreTool
+
 __version__ = "0.1.0"
 
 __all__ = [
@@ -59,4 +62,6 @@ __all__ = [
     # YAML tools
     "YamlToolBase",
     "discover_and_register_yaml_tools",
+    # Tools
+    "KVStoreTool",
 ]

--- a/mcp_tools/kv_store/__init__.py
+++ b/mcp_tools/kv_store/__init__.py
@@ -1,0 +1,5 @@
+"""In-memory key-value store tool with TTL support."""
+
+from .tool import KVStoreTool
+
+__all__ = ["KVStoreTool"]

--- a/mcp_tools/kv_store/tool.py
+++ b/mcp_tools/kv_store/tool.py
@@ -1,0 +1,246 @@
+import time
+import threading
+from typing import Dict, Any, Optional
+from mcp_tools.interfaces import ToolInterface
+from mcp_tools.plugin import register_tool
+
+
+class KVStore:
+    """Thread-safe in-memory key-value store with TTL support."""
+
+    def __init__(self):
+        self._store: Dict[str, Dict[str, Any]] = {}
+        self._lock = threading.RLock()
+
+    def set(self, key: str, value: Any, ttl_seconds: Optional[int] = None) -> None:
+        """Set a key-value pair with optional TTL."""
+        with self._lock:
+            expiry = None
+            if ttl_seconds is not None:
+                expiry = time.time() + ttl_seconds
+
+            self._store[key] = {
+                'value': value,
+                'expiry': expiry,
+                'created_at': time.time()
+            }
+
+    def get(self, key: str) -> Optional[Any]:
+        """Get a value by key, returns None if key doesn't exist or has expired."""
+        with self._lock:
+            if key not in self._store:
+                return None
+
+            entry = self._store[key]
+
+            # Check if expired
+            if entry['expiry'] is not None and time.time() > entry['expiry']:
+                del self._store[key]
+                return None
+
+            return entry['value']
+
+    def delete(self, key: str) -> bool:
+        """Delete a key, returns True if key existed."""
+        with self._lock:
+            if key in self._store:
+                del self._store[key]
+                return True
+            return False
+
+    def exists(self, key: str) -> bool:
+        """Check if key exists and hasn't expired."""
+        with self._lock:
+            if key not in self._store:
+                return False
+
+            entry = self._store[key]
+
+            # Check if expired
+            if entry['expiry'] is not None and time.time() > entry['expiry']:
+                del self._store[key]
+                return False
+
+            return True
+
+    def keys(self) -> list[str]:
+        """Get all non-expired keys."""
+        with self._lock:
+            current_time = time.time()
+            valid_keys = []
+            expired_keys = []
+
+            for key, entry in self._store.items():
+                if entry['expiry'] is not None and current_time > entry['expiry']:
+                    expired_keys.append(key)
+                else:
+                    valid_keys.append(key)
+
+            # Clean up expired keys
+            for key in expired_keys:
+                del self._store[key]
+
+            return valid_keys
+
+    def clear(self) -> int:
+        """Clear all keys, returns number of keys cleared."""
+        with self._lock:
+            count = len(self._store)
+            self._store.clear()
+            return count
+
+    def ttl(self, key: str) -> Optional[int]:
+        """Get TTL for a key in seconds, returns None if key doesn't exist or has no TTL."""
+        with self._lock:
+            if key not in self._store:
+                return None
+
+            entry = self._store[key]
+
+            if entry['expiry'] is None:
+                return -1  # No TTL set
+
+            remaining = entry['expiry'] - time.time()
+            if remaining <= 0:
+                del self._store[key]
+                return None
+
+            return int(remaining)
+
+
+# Global KV store instance
+_kv_store = KVStore()
+
+
+@register_tool()
+class KVStoreTool(ToolInterface):
+    """In-memory key-value store tool with TTL support."""
+
+    @property
+    def name(self) -> str:
+        return "kv_store"
+
+    @property
+    def description(self) -> str:
+        return (
+            "In-memory key-value store with TTL support. "
+            "Supports operations: set, get, delete, exists, keys, clear, ttl. "
+            "Default TTL is 1 day (86400 seconds)."
+        )
+
+    @property
+    def input_schema(self) -> Dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "operation": {
+                    "type": "string",
+                    "description": "The operation to perform",
+                    "enum": ["set", "get", "delete", "exists", "keys", "clear", "ttl"]
+                },
+                "key": {
+                    "type": "string",
+                    "description": "The key for the operation (required for all operations except 'keys' and 'clear')"
+                },
+                "value": {
+                    "description": "The value to store (required for 'set' operation)",
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "number"},
+                        {"type": "boolean"},
+                        {"type": "object"},
+                        {"type": "array", "items": {}}
+                    ]
+                },
+                "ttl": {
+                    "type": "integer",
+                    "description": "Time-to-live in seconds (default: 86400 = 1 day). Use -1 for no expiration.",
+                    "default": 86400
+                }
+            },
+            "required": ["operation"]
+        }
+
+    async def execute_tool(self, arguments: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute KV store operation."""
+        operation = arguments.get("operation")
+        key = arguments.get("key")
+        value = arguments.get("value")
+        ttl = arguments.get("ttl", 86400)
+        try:
+            if operation == "set":
+                if key is None:
+                    return {"success": False, "error": "Key is required for set operation"}
+                if value is None:
+                    return {"success": False, "error": "Value is required for set operation"}
+
+                ttl_seconds = None if ttl == -1 else ttl
+                _kv_store.set(key, value, ttl_seconds)
+                return {
+                    "success": True,
+                    "message": f"Set key '{key}' with TTL {ttl} seconds" if ttl != -1 else f"Set key '{key}' with no expiration"
+                }
+
+            elif operation == "get":
+                if key is None:
+                    return {"success": False, "error": "Key is required for get operation"}
+
+                result = _kv_store.get(key)
+                if result is None:
+                    return {"success": False, "message": f"Key '{key}' not found or expired"}
+
+                return {"success": True, "value": result}
+
+            elif operation == "delete":
+                if key is None:
+                    return {"success": False, "error": "Key is required for delete operation"}
+
+                deleted = _kv_store.delete(key)
+                if deleted:
+                    return {"success": True, "message": f"Deleted key '{key}'"}
+                else:
+                    return {"success": False, "message": f"Key '{key}' not found"}
+
+            elif operation == "exists":
+                if key is None:
+                    return {"success": False, "error": "Key is required for exists operation"}
+
+                exists = _kv_store.exists(key)
+                return {"success": True, "exists": exists}
+
+            elif operation == "keys":
+                keys = _kv_store.keys()
+                return {"success": True, "keys": keys, "count": len(keys)}
+
+            elif operation == "clear":
+                count = _kv_store.clear()
+                return {"success": True, "message": f"Cleared {count} keys"}
+
+            elif operation == "ttl":
+                if key is None:
+                    return {"success": False, "error": "Key is required for ttl operation"}
+
+                ttl_remaining = _kv_store.ttl(key)
+                if ttl_remaining is None:
+                    return {"success": False, "message": f"Key '{key}' not found or expired"}
+                elif ttl_remaining == -1:
+                    return {"success": True, "ttl": -1, "message": f"Key '{key}' has no expiration"}
+                else:
+                    return {"success": True, "ttl": ttl_remaining, "message": f"Key '{key}' expires in {ttl_remaining} seconds"}
+
+            else:
+                return {"success": False, "error": f"Unknown operation: {operation}"}
+
+        except Exception as e:
+            return {"success": False, "error": f"Operation failed: {str(e)}"}
+
+    def execute(self, operation: str, key: Optional[str] = None, value: Any = None, ttl: int = 86400) -> Dict[str, Any]:
+        """Synchronous wrapper for execute_tool for backwards compatibility and testing."""
+        import asyncio
+        arguments = {
+            "operation": operation,
+            "key": key,
+            "value": value,
+            "ttl": ttl
+        }
+        return asyncio.run(self.execute_tool(arguments))

--- a/mcp_tools/tests/test_kv_store.py
+++ b/mcp_tools/tests/test_kv_store.py
@@ -1,0 +1,353 @@
+import time
+import threading
+import pytest
+from mcp_tools.kv_store.tool import KVStoreTool, KVStore
+
+
+class TestKVStore:
+    """Test the KVStore class directly."""
+
+    def setup_method(self):
+        """Set up a fresh KVStore for each test."""
+        self.kv = KVStore()
+
+    def test_basic_set_get(self):
+        """Test basic set and get operations."""
+        self.kv.set("test_key", "test_value")
+        assert self.kv.get("test_key") == "test_value"
+
+    def test_get_nonexistent_key(self):
+        """Test getting a key that doesn't exist."""
+        assert self.kv.get("nonexistent") is None
+
+    def test_set_with_ttl(self):
+        """Test setting a key with TTL."""
+        self.kv.set("ttl_key", "ttl_value", ttl_seconds=1)
+        assert self.kv.get("ttl_key") == "ttl_value"
+
+        # Wait for expiration
+        time.sleep(1.1)
+        assert self.kv.get("ttl_key") is None
+
+    def test_delete(self):
+        """Test delete operation."""
+        self.kv.set("delete_key", "delete_value")
+        assert self.kv.delete("delete_key") is True
+        assert self.kv.get("delete_key") is None
+        assert self.kv.delete("delete_key") is False  # Already deleted
+
+    def test_exists(self):
+        """Test exists operation."""
+        assert self.kv.exists("nonexistent") is False
+
+        self.kv.set("exists_key", "exists_value")
+        assert self.kv.exists("exists_key") is True
+
+        self.kv.set("expired_key", "expired_value", ttl_seconds=1)
+        assert self.kv.exists("expired_key") is True
+        time.sleep(1.1)
+        assert self.kv.exists("expired_key") is False
+
+    def test_keys(self):
+        """Test keys operation."""
+        assert self.kv.keys() == []
+
+        self.kv.set("key1", "value1")
+        self.kv.set("key2", "value2")
+        self.kv.set("expired", "expired_value", ttl_seconds=1)
+
+        keys = self.kv.keys()
+        assert "key1" in keys
+        assert "key2" in keys
+        assert "expired" in keys
+        assert len(keys) == 3
+
+        # Wait for expiration
+        time.sleep(1.1)
+        keys = self.kv.keys()
+        assert "key1" in keys
+        assert "key2" in keys
+        assert "expired" not in keys
+        assert len(keys) == 2
+
+    def test_clear(self):
+        """Test clear operation."""
+        self.kv.set("key1", "value1")
+        self.kv.set("key2", "value2")
+
+        count = self.kv.clear()
+        assert count == 2
+        assert self.kv.keys() == []
+
+    def test_ttl(self):
+        """Test TTL operation."""
+        # Key doesn't exist
+        assert self.kv.ttl("nonexistent") is None
+
+        # Key without TTL
+        self.kv.set("no_ttl", "value")
+        assert self.kv.ttl("no_ttl") == -1
+
+        # Key with TTL
+        self.kv.set("with_ttl", "value", ttl_seconds=10)
+        ttl = self.kv.ttl("with_ttl")
+        assert ttl is not None
+        assert 9 <= ttl <= 10  # Should be close to 10
+
+        # Expired key
+        self.kv.set("expired", "value", ttl_seconds=1)
+        time.sleep(1.1)
+        assert self.kv.ttl("expired") is None
+
+    def test_different_value_types(self):
+        """Test storing different types of values."""
+        # String
+        self.kv.set("string_key", "string_value")
+        assert self.kv.get("string_key") == "string_value"
+
+        # Integer
+        self.kv.set("int_key", 42)
+        assert self.kv.get("int_key") == 42
+
+        # Float
+        self.kv.set("float_key", 3.14)
+        assert self.kv.get("float_key") == 3.14
+
+        # Boolean
+        self.kv.set("bool_key", True)
+        assert self.kv.get("bool_key") is True
+
+        # List
+        self.kv.set("list_key", [1, 2, 3])
+        assert self.kv.get("list_key") == [1, 2, 3]
+
+        # Dict
+        self.kv.set("dict_key", {"foo": "bar"})
+        assert self.kv.get("dict_key") == {"foo": "bar"}
+
+    def test_thread_safety(self):
+        """Test thread safety of the KV store."""
+        def worker(worker_id):
+            for i in range(100):
+                key = f"worker_{worker_id}_key_{i}"
+                value = f"worker_{worker_id}_value_{i}"
+                self.kv.set(key, value)
+                assert self.kv.get(key) == value
+
+        threads = []
+        for i in range(5):
+            thread = threading.Thread(target=worker, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Verify all keys are present
+        keys = self.kv.keys()
+        assert len(keys) == 500  # 5 workers * 100 keys each
+
+
+class TestKVStoreTool:
+    """Test the KVStoreTool class."""
+
+    def setup_method(self):
+        """Set up a fresh KVStoreTool for each test."""
+        self.tool = KVStoreTool()
+        # Clear the global store before each test
+        self.tool.execute("clear")
+
+    def test_tool_properties(self):
+        """Test tool properties."""
+        assert self.tool.name == "kv_store"
+        assert "key-value store" in self.tool.description.lower()
+        assert "ttl" in self.tool.description.lower()
+
+        schema = self.tool.input_schema
+        assert schema["type"] == "object"
+        assert "operation" in schema["properties"]
+        assert "key" in schema["properties"]
+        assert "value" in schema["properties"]
+        assert "ttl" in schema["properties"]
+
+    def test_set_operation(self):
+        """Test set operation."""
+        result = self.tool.execute("set", "test_key", "test_value")
+        assert result["success"] is True
+        assert "Set key 'test_key'" in result["message"]
+
+        # Test set with custom TTL
+        result = self.tool.execute("set", "ttl_key", "ttl_value", ttl=60)
+        assert result["success"] is True
+        assert "60 seconds" in result["message"]
+
+        # Test set with no TTL
+        result = self.tool.execute("set", "no_ttl_key", "no_ttl_value", ttl=-1)
+        assert result["success"] is True
+        assert "no expiration" in result["message"]
+
+    def test_set_operation_errors(self):
+        """Test set operation error cases."""
+        # Missing key
+        result = self.tool.execute("set", value="test_value")
+        assert result["success"] is False
+        assert "Key is required" in result["error"]
+
+        # Missing value
+        result = self.tool.execute("set", "test_key")
+        assert result["success"] is False
+        assert "Value is required" in result["error"]
+
+    def test_get_operation(self):
+        """Test get operation."""
+        # Set a value first
+        self.tool.execute("set", "test_key", "test_value")
+
+        result = self.tool.execute("get", "test_key")
+        assert result["success"] is True
+        assert result["value"] == "test_value"
+
+        # Test getting nonexistent key
+        result = self.tool.execute("get", "nonexistent")
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+    def test_get_operation_errors(self):
+        """Test get operation error cases."""
+        # Missing key
+        result = self.tool.execute("get")
+        assert result["success"] is False
+        assert "Key is required" in result["error"]
+
+    def test_delete_operation(self):
+        """Test delete operation."""
+        # Set a value first
+        self.tool.execute("set", "test_key", "test_value")
+
+        result = self.tool.execute("delete", "test_key")
+        assert result["success"] is True
+        assert "Deleted key 'test_key'" in result["message"]
+
+        # Try to delete again
+        result = self.tool.execute("delete", "test_key")
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+    def test_delete_operation_errors(self):
+        """Test delete operation error cases."""
+        # Missing key
+        result = self.tool.execute("delete")
+        assert result["success"] is False
+        assert "Key is required" in result["error"]
+
+    def test_exists_operation(self):
+        """Test exists operation."""
+        result = self.tool.execute("exists", "nonexistent")
+        assert result["success"] is True
+        assert result["exists"] is False
+
+        # Set a value
+        self.tool.execute("set", "test_key", "test_value")
+
+        result = self.tool.execute("exists", "test_key")
+        assert result["success"] is True
+        assert result["exists"] is True
+
+    def test_exists_operation_errors(self):
+        """Test exists operation error cases."""
+        # Missing key
+        result = self.tool.execute("exists")
+        assert result["success"] is False
+        assert "Key is required" in result["error"]
+
+    def test_keys_operation(self):
+        """Test keys operation."""
+        result = self.tool.execute("keys")
+        assert result["success"] is True
+        assert result["keys"] == []
+        assert result["count"] == 0
+
+        # Add some keys
+        self.tool.execute("set", "key1", "value1")
+        self.tool.execute("set", "key2", "value2")
+
+        result = self.tool.execute("keys")
+        assert result["success"] is True
+        assert "key1" in result["keys"]
+        assert "key2" in result["keys"]
+        assert result["count"] == 2
+
+    def test_clear_operation(self):
+        """Test clear operation."""
+        # Add some keys
+        self.tool.execute("set", "key1", "value1")
+        self.tool.execute("set", "key2", "value2")
+
+        result = self.tool.execute("clear")
+        assert result["success"] is True
+        assert "Cleared 2 keys" in result["message"]
+
+        # Verify keys are cleared
+        result = self.tool.execute("keys")
+        assert result["count"] == 0
+
+    def test_ttl_operation(self):
+        """Test TTL operation."""
+        # Nonexistent key
+        result = self.tool.execute("ttl", "nonexistent")
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+        # Key without TTL
+        self.tool.execute("set", "no_ttl", "value", ttl=-1)
+        result = self.tool.execute("ttl", "no_ttl")
+        assert result["success"] is True
+        assert result["ttl"] == -1
+        assert "no expiration" in result["message"]
+
+        # Key with TTL
+        self.tool.execute("set", "with_ttl", "value", ttl=60)
+        result = self.tool.execute("ttl", "with_ttl")
+        assert result["success"] is True
+        assert 55 <= result["ttl"] <= 60  # Should be close to 60
+        assert "expires in" in result["message"]
+
+    def test_ttl_operation_errors(self):
+        """Test TTL operation error cases."""
+        # Missing key
+        result = self.tool.execute("ttl")
+        assert result["success"] is False
+        assert "Key is required" in result["error"]
+
+    def test_unknown_operation(self):
+        """Test unknown operation."""
+        result = self.tool.execute("unknown_operation")
+        assert result["success"] is False
+        assert "Unknown operation" in result["error"]
+
+    def test_ttl_expiration(self):
+        """Test that TTL expiration works correctly."""
+        # Set a key with short TTL
+        self.tool.execute("set", "short_ttl", "value", ttl=1)
+
+        # Should exist initially
+        result = self.tool.execute("get", "short_ttl")
+        assert result["success"] is True
+
+        # Wait for expiration
+        time.sleep(1.1)
+
+        # Should not exist after expiration
+        result = self.tool.execute("get", "short_ttl")
+        assert result["success"] is False
+        assert "not found" in result["message"]
+
+    def test_default_ttl(self):
+        """Test that default TTL is applied."""
+        # Set without specifying TTL (should use default 86400)
+        self.tool.execute("set", "default_ttl", "value")
+
+        result = self.tool.execute("ttl", "default_ttl")
+        assert result["success"] is True
+        # Should be close to 86400 (1 day)
+        assert 86390 <= result["ttl"] <= 86400


### PR DESCRIPTION
- Implements thread-safe in-memory key-value store with optional TTL
- Supports operations: set, get, delete, exists, keys, clear, ttl
- Default TTL is 1 day (86400 seconds), configurable per key
- Comprehensive test coverage with 26 test cases
- Automatic cleanup of expired keys on access
- Thread-safe operations using RLock

🤖 Generated with [Claude Code](https://claude.ai/code)