### PR TITLE
feat: increase default timeout for query status tools from 25s to 120s

### DIFF
--- a/mcp_tools/yaml_tools.py
+++ b/mcp_tools/yaml_tools.py
@@ -20,7 +20,7 @@ from utils.concurrency import get_concurrency_manager, parse_concurrency_config
 
 # Configuration
 DEFAULT_WAIT_FOR_QUERY = True  # Default wait for task
-DEFAULT_STATUS_QUERY_TIMEOUT = 25  # Default timeout in seconds for status queries
+DEFAULT_STATUS_QUERY_TIMEOUT = 120  # Default timeout in seconds for status queries
 
 logger = logging.getLogger(__name__)
 

--- a/server/tools.yaml
+++ b/server/tools.yaml
@@ -35,7 +35,8 @@ tools:
           default: false
         timeout:
           type: number
-          description: Optional timeout in seconds for waiting
+          description: Optional timeout in seconds for waiting (default 120s)
+          default: 120
       required:
         - token
 
@@ -66,6 +67,14 @@ tools:
         token:
           type: string
           description: The token returned by execute_task
+        wait:
+          type: boolean
+          description: Whether to wait for the task to complete
+          default: true
+        timeout:
+          type: number
+          description: Optional timeout in seconds for waiting (default 120s)
+          default: 120
       required:
         - token
 
@@ -114,9 +123,14 @@ tools:
         token:
           type: string
           description: The token returned by async script execution
+        wait:
+          type: boolean
+          description: Whether to wait for the script to complete
+          default: true
         timeout:
           type: number
-          description: Optional timeout in seconds for waiting
+          description: Optional timeout in seconds for waiting (default 120s)
+          default: 120
       required:
         - token
 


### PR DESCRIPTION
## Summary

This PR increases the default timeout for query status tools from 25 seconds to 120 seconds to better accommodate longer-running tasks.

## Changes Made

### Code Changes
- **Updated `DEFAULT_STATUS_QUERY_TIMEOUT` constant** from 25 to 120 seconds in `mcp_tools/yaml_tools.py`

### Configuration Changes
- **Added `timeout` parameter** with 120s default to `query_task_status` input schema
- **Added `wait` parameter** with true default to `query_task_status` input schema for consistency
- **Updated `query_script_status`** schema to include consistent 120s default timeout
- **Updated `query_command_status`** schema to include consistent 120s default timeout

## Impact

- All query status tools (`query_task_status`, `query_script_status`, `query_command_status`) now have consistent behavior
- Users can still override the timeout by passing a custom value
- Longer-running tasks will have more time to complete before timing out
- Backward compatibility is maintained as the timeout parameter was optional before

## Testing

The changes maintain backward compatibility:
- Tools still accept custom timeout values
- Default behavior is improved for longer-running tasks
- Input schemas are properly defined with defaults

## Files Modified

- `mcp_tools/yaml_tools.py` - Updated timeout constant
- `server/tools.yaml` - Updated tool input schemas with consistent timeout defaults