### PR TITLE
Fix semantic-release build_command type error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ dev = [
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 upload_to_vcs_release = false
-build_command = false
+build_command = ""
 commit_message = "chore: release {version}"
 
 [tool.semantic_release.commit_parser_options]


### PR DESCRIPTION
## Problem

The daily-version.yml GitHub Actions workflow was failing with a Pydantic validation error:

```
1 validation error for RawConfig
build_command
  Input should be a valid string [type=string_type, input_value=False, input_type=bool]
```

## Root Cause

The `python-semantic-release` tool expects the `build_command` configuration to be a string type, but it was set to a boolean `false` in `pyproject.toml`.

## Solution

Changed `build_command = false` to `build_command = ""` in the `[tool.semantic_release]` section of `pyproject.toml`.

This maintains the same behavior (no build command) while satisfying the string type requirement.

## Testing

- [x] Verified the configuration change maintains intended behavior
- [x] The empty string correctly indicates "no build command" to semantic-release
- [x] Pre-commit hooks pass

## Files Changed

- `pyproject.toml`: Updated semantic-release configuration

## Impact

- ✅ Fixes the daily version bump workflow
- ✅ No functional changes to the release process
- ✅ Maintains backward compatibility