### PR TITLE
feat: split extension CI into two workflows

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -9,40 +9,40 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [18.x, 20.x]
-        
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
         cache-dependency-path: wu-wei/package-lock.json
-        
+
     - name: Change to wu-wei directory
       run: cd wu-wei
-      
+
     - name: Install dependencies
       run: |
         cd wu-wei
         npm ci
-        
+
     - name: Run linter
       run: |
         cd wu-wei
         npm run lint
-        
+
     - name: Compile TypeScript
       run: |
         cd wu-wei
         npm run compile
-        
+
     - name: Run tests
       run: |
         cd wu-wei
@@ -50,38 +50,3 @@ jobs:
       env:
         # Display needed for VS Code tests
         DISPLAY: ':99.0'
-        
-  package:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      
-    - name: Use Node.js 20
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: 'npm'
-        cache-dependency-path: wu-wei/package-lock.json
-        
-    - name: Install dependencies
-      run: |
-        cd wu-wei
-        npm ci
-        
-    - name: Install vsce
-      run: npm install -g @vscode/vsce
-      
-    - name: Package extension
-      run: |
-        cd wu-wei
-        vsce package
-        
-    - name: Upload package artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wu-wei-extension
-        path: wu-wei/*.vsix

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -1,0 +1,40 @@
+name: Package Wu Wei Extension
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Every day at midnight UTC
+  workflow_dispatch:
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Use Node.js 20
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: wu-wei/package-lock.json
+
+    - name: Install dependencies
+      run: |
+        cd wu-wei
+        npm ci
+
+    - name: Install vsce
+      run: npm install -g @vscode/vsce
+
+    - name: Package extension
+      run: |
+        cd wu-wei
+        vsce package
+
+    - name: Upload package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wu-wei-extension
+        path: wu-wei/*.vsix


### PR DESCRIPTION
This PR splits the extension CI into two workflows: one for building and testing, and another for packaging.