### PR TITLE
fix: improve playwright test stability (Gemini)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           source .venv/bin/activate
           chmod +x ./scripts/run_component_group.sh
-          ./scripts/run_component_group.sh server-group
+          ./scripts/run_component_group.sh server-group --reruns 2
 
       - name: Run Server Group Tests (Windows)
         if: runner.os == 'Windows' && matrix.component == 'server-group'
@@ -117,7 +117,7 @@ jobs:
         run: |
           source .venv/Scripts/activate
           chmod +x ./scripts/run_component_group.sh
-          ./scripts/run_component_group.sh server-group
+          ./scripts/run_component_group.sh server-group --reruns 2
 
       - name: Run Utils Group 1 Tests (Unix)
         if: runner.os != 'Windows' && matrix.component == 'utils-group-1'
@@ -139,7 +139,7 @@ jobs:
         run: |
           source .venv/bin/activate
           chmod +x ./scripts/run_component_group.sh
-          ./scripts/run_component_group.sh utils-group-2
+          ./scripts/run_component_group.sh utils-group-2 --reruns 2
 
       - name: Run Utils Group 2 Tests (Windows)
         if: runner.os == 'Windows' && matrix.component == 'utils-group-2'
@@ -147,7 +147,7 @@ jobs:
         run: |
           source .venv/Scripts/activate
           chmod +x ./scripts/run_component_group.sh
-          ./scripts/run_component_group.sh utils-group-2
+          ./scripts/run_component_group.sh utils-group-2 --reruns 2
 
       - name: Run Plugins Group 1 Tests (Unix)
         if: runner.os != 'Windows' && matrix.component == 'plugins-group-1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,13 +81,13 @@ jobs:
         if: runner.os != 'Windows' && (matrix.component == 'utils-group-2' || matrix.component == 'server-group')
         run: |
           source .venv/bin/activate
-          playwright install chromium
+          playwright install
 
       - name: Install Playwright Browsers (Windows)
         if: runner.os == 'Windows' && (matrix.component == 'utils-group-2' || matrix.component == 'server-group')
         run: |
           .venv\Scripts\activate
-          playwright install chromium
+          playwright install
 
       - name: Run Core Group Tests (Unix)
         if: runner.os != 'Windows' && matrix.component == 'core-group'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "pytest-asyncio>=0.21.1",
     "pytest-xdist>=3.3.1", # Parallel test execution
     "pytest-timeout>=2.1.0", # Test timeout support
+    "pytest-rerunfailures>=10.2", # Pytest plugin to re-run failed tests
     "requests>=2.31.0", # HTTP client for testing
     # Azure Data Explorer (Kusto)
     "azure-kusto-data>=5.0.0", # Azure Data Explorer client


### PR DESCRIPTION
This PR improves the stability of the Playwright tests by:

- Installing all Playwright browsers in the CI environment.
- Adding a retry mechanism to the Playwright tests.

Editor: gemini-cli