### PR TITLE
feat: make kusto database parameter optional (Gemini)

### DIFF
--- a/plugins/kusto/tool.py
+++ b/plugins/kusto/tool.py
@@ -79,7 +79,7 @@ class KustoClient(KustoClientInterface):
                     "default": True,
                 },
             },
-            "required": ["operation", "database", "query"],
+            "required": ["operation", "query"],
         }
 
     def __init__(self, config_dict=None):


### PR DESCRIPTION
This PR makes the database parameter optional for the Kusto tool. The tool will now fall back to the environment configuration if the database is not provided.

Editor: gemini-cli