### PR TITLE
fix: update daily version workflow to create PR instead of direct push

### DIFF
--- a/.github/workflows/daily-version.yml
+++ b/.github/workflows/daily-version.yml
@@ -32,8 +32,11 @@ jobs:
         id: semantic
         run: |
           source .venv/bin/activate
-          NEW_VERSION=$(semantic-release version)
-          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          NEW_VERSION=$(semantic-release version --print)
+          if [ -n "$NEW_VERSION" ] && [ "$NEW_VERSION" != "$(git describe --tags --abbrev=0 2>/dev/null || echo '0.0.0')" ]; then
+            echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+            semantic-release version --no-push --no-tag --no-commit
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Modified semantic-release step to use `--print` flag to preview version changes
- Added conditional logic to only proceed if there's a new version
- Used `--no-push --no-tag --no-commit` flags to prevent direct commits to main branch

## Test plan
- [ ] Verify the daily version workflow runs without permission errors
- [ ] Confirm PRs are created instead of direct pushes to main
- [ ] Test version bumping logic works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)