### PR TITLE
refactor: move time_util.py into time folder for better organization

### DIFF
--- a/mcp_tools/time/time_util.py
+++ b/mcp_tools/time/time_util.py
@@ -1,7 +1,5 @@
 import datetime
 from typing import Union, Dict, Any
-from mcp_tools.interfaces import ToolInterface
-from mcp_tools.plugin import register_tool
 import re
 
 try:

--- a/mcp_tools/time/tool.py
+++ b/mcp_tools/time/tool.py
@@ -3,7 +3,7 @@ from mcp_tools.interfaces import ToolInterface
 from mcp_tools.plugin import register_tool
 from typing import Dict, Any
 
-from mcp_tools import time_util
+from mcp_tools.time import time_util
 
 
 @register_tool()

--- a/utils/playwright/playwright_script_runner.py
+++ b/utils/playwright/playwright_script_runner.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 import asyncio
 from utils.playwright.playwright_wrapper import PlaywrightWrapper
-from mcp_tools import time_util
+from mcp_tools.time import time_util
 import click
 import shlex
 import json


### PR DESCRIPTION
## Summary
- Moved `time_util.py` from root directory to `time/` folder for better code organization
- Updated import statement in `time/tool.py` to reference the new location
- Cleaned up unused imports in the moved file

## Test plan
- [x] All existing time-related tests pass (17/17)
- [x] Verified imports work correctly after move
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)