### PR TITLE
Fix: Resolve webview packaging issue in Wu Wei extension

### DIFF
--- a/wu-wei/package.json
+++ b/wu-wei/package.json
@@ -347,7 +347,8 @@
     },
     "scripts": {
         "vscode:prepublish": "npm run compile",
-        "compile": "tsc -p ./",
+        "compile": "npm run clean && tsc -p ./ && npm run copy-webview",
+        "copy-webview": "cp -r src/webview out/",
         "watch": "tsc -watch -p ./",
         "pretest": "npm run compile && npm run lint",
         "lint": "eslint src --ext ts",

--- a/wu-wei/src/promptStore/PromptStoreProvider.ts
+++ b/wu-wei/src/promptStore/PromptStoreProvider.ts
@@ -611,10 +611,10 @@ export class PromptStoreProvider implements vscode.WebviewViewProvider {
     private getHtmlForWebview(webview: vscode.Webview): string {
         // Get resource URIs
         const scriptUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this.extensionUri, 'src', 'webview', 'promptStore', 'main.js')
+            vscode.Uri.joinPath(this.extensionUri, 'out', 'webview', 'promptStore', 'main.js')
         );
         const styleUri = webview.asWebviewUri(
-            vscode.Uri.joinPath(this.extensionUri, 'src', 'webview', 'promptStore', 'style.css')
+            vscode.Uri.joinPath(this.extensionUri, 'out', 'webview', 'promptStore', 'style.css')
         );
 
         // Use a nonce to only allow specific scripts to be run

--- a/wu-wei/src/providers/BaseWebviewProvider.ts
+++ b/wu-wei/src/providers/BaseWebviewProvider.ts
@@ -27,13 +27,13 @@ export abstract class BaseWebviewProvider {
         jsFiles: string[] = []
     ): string {
         try {
-            const htmlPath = path.join(this.context.extensionPath, 'src', 'webview', htmlFile);
+            const htmlPath = path.join(this.context.extensionPath, 'out', 'webview', htmlFile);
             let html = fs.readFileSync(htmlPath, 'utf8');
 
             // Replace CSS URIs
             cssFiles.forEach((cssFile, index) => {
                 const cssUri = webview.asWebviewUri(
-                    vscode.Uri.joinPath(this.context.extensionUri, 'src', 'webview', cssFile)
+                    vscode.Uri.joinPath(this.context.extensionUri, 'out', 'webview', cssFile)
                 );
                 html = html.replace(`{{${this.getCssPlaceholder(index)}}}`, cssUri.toString());
             });
@@ -41,7 +41,7 @@ export abstract class BaseWebviewProvider {
             // Replace JS URIs
             jsFiles.forEach((jsFile, index) => {
                 const jsUri = webview.asWebviewUri(
-                    vscode.Uri.joinPath(this.context.extensionUri, 'src', 'webview', jsFile)
+                    vscode.Uri.joinPath(this.context.extensionUri, 'out', 'webview', jsFile)
                 );
                 html = html.replace(`{{${this.getJsPlaceholder(index)}}}`, jsUri.toString());
             });


### PR DESCRIPTION
## Problem
The Wu Wei extension was failing to load webview content with errors like:
```
Error: ENOENT: no such file or directory, open '/Users/.../extensions/your-publisher-name.wu-wei-0.1.0/src/webview/chat/index.html'
```

This occurred because the extension code was looking for webview files in `src/webview/` but the packaged extension excluded all `src/**` files via `.vscodeignore`.

## Solution
### 🔧 Build Process Enhancement
- **Updated build script**: Added `copy-webview` step to copy static webview assets to `out/` directory
- **Enhanced compile process**: Now runs `clean` → `tsc` → `copy-webview` in sequence

### 📁 File Path Corrections  
- **BaseWebviewProvider.ts**: Updated all file path references from `'src', 'webview'` to `'out', 'webview'`
- **PromptStoreProvider.ts**: Fixed webview resource URI paths to use compiled output directory

### 📦 Packaging Verification
- ✅ All webview HTML files now included in package
- ✅ CSS and JavaScript assets properly copied
- ✅ Extension packages successfully (636KB total)
- ✅ GitHub Actions workflow compatible

## Testing
- [x] Extension compiles without errors
- [x] Webview files copied to `out/webview/` directory
- [x] Extension packages successfully with `vsce package`
- [x] All webview assets included in final `.vsix` file

## Impact
- **Chat Panel**: Will now load correctly ✅
- **Prompt Store**: Will display properly ✅  
- **Agent Panel**: Will function as expected ✅
- **Debug Panel**: Will load without errors ✅

This resolves the "Failed to load content" errors across all webview panels in the Wu Wei extension.