### PR TITLE
feat: add auto-merge to daily version workflow

### DIFF
--- a/.github/workflows/daily-version.yml
+++ b/.github/workflows/daily-version.yml
@@ -50,3 +50,15 @@ jobs:
           body: "Automated version bump to ${{ env.NEW_VERSION }}"
           branch: "release/${{ env.NEW_VERSION }}"
           base: "main"
+
+      - name: Enable auto-merge for Pull Request
+        if: env.NEW_VERSION
+        run: |
+          # Get the PR number from the previous step
+          PR_NUMBER=$(gh pr list --head "release/${{ env.NEW_VERSION }}" --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            gh pr merge $PR_NUMBER --auto --squash
+            echo "Auto-merge enabled for PR #$PR_NUMBER"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

This PR adds auto-merge functionality to the daily version bump workflow.

## Changes
- Added a new step to enable auto-merge for PRs created by the daily version workflow
- The workflow will now automatically merge version bump PRs using the squash strategy
- This ensures automated releases are processed without manual intervention

## Why
- Reduces manual overhead for routine version bumps
- Ensures consistent and timely release processing
- Maintains the automated nature of the daily version workflow

## Testing
- The workflow change is tested through GitHub Actions
- Auto-merge will only be enabled if a version bump is actually needed