### PR TITLE
Update .vscodeignore to exclude test fixtures and docs

### DIFF
--- a/wu-wei/.vscodeignore
+++ b/wu-wei/.vscodeignore
@@ -22,3 +22,7 @@ node_modules/*
 !node_modules/chokidar/**
 !node_modules/yaml/**
 !node_modules/@vscode/prompt-tsx/**
+
+# Ignore test fixtures and docs
+test-fixtures/**
+docs/**


### PR DESCRIPTION
## Summary

Updates the `.vscodeignore` file in the wu-wei extension to exclude test fixtures and documentation files from the VS Code extension package.

## Changes

- Add `test-fixtures/**` to ignore list to exclude test data from extension package
- Add `docs/**` to ignore list to reduce package size
- Improves extension packaging by excluding non-essential files

## Benefits

- Reduces extension package size by excluding unnecessary files
- Follows VS Code extension best practices for packaging
- Keeps the extension focused on runtime code and assets

## Testing

- [x] Pre-commit hooks pass
- [x] Changes only affect packaging, not functionality