### PR TITLE
Fix issue #364: Hide prompt variables section when template has no va…

### DIFF
--- a/wu-wei/src/webview/agent/index.html
+++ b/wu-wei/src/webview/agent/index.html
@@ -73,6 +73,7 @@
                 <label class="form-label">Input Mode</label>
                 <select id="promptModeSelector">
                     <option value="custom">Custom Message</option>
+                    <option value="prompt">Prompt Only</option>
                     <option value="combined">Prompt + Custom Message</option>
                 </select>
             </div>

--- a/wu-wei/src/webview/agent/main.js
+++ b/wu-wei/src/webview/agent/main.js
@@ -136,9 +136,18 @@ function updateUIForPromptMode() {
             variableEditorContainer.style.display = 'none';
             promptPreviewContainer.style.display = 'none';
             break;
+        case 'prompt':
+            promptSelectorContainer.style.display = 'block';
+            // Only show variable editor if prompt has variables
+            const hasVariablesPrompt = selectedPromptContext?.parameters?.length > 0;
+            variableEditorContainer.style.display = selectedPromptContext && hasVariablesPrompt ? 'block' : 'none';
+            promptPreviewContainer.style.display = selectedPromptContext ? 'block' : 'none';
+            break;
         case 'combined':
             promptSelectorContainer.style.display = 'block';
-            variableEditorContainer.style.display = selectedPromptContext ? 'block' : 'none';
+            // Only show variable editor if prompt has variables
+            const hasVariables = selectedPromptContext?.parameters?.length > 0;
+            variableEditorContainer.style.display = selectedPromptContext && hasVariables ? 'block' : 'none';
             promptPreviewContainer.style.display = selectedPromptContext ? 'block' : 'none';
             break;
     }
@@ -150,6 +159,11 @@ function updateInputLabelsAndPlaceholders() {
             parameterSubtitle.textContent = 'Enter your message or JSON parameters';
             parametersLabel.textContent = 'Message/Parameters';
             paramsInput.placeholder = 'Enter your message or JSON parameters...';
+            break;
+        case 'prompt':
+            parameterSubtitle.textContent = 'Use selected prompt template only';
+            parametersLabel.textContent = 'Additional Parameters (Optional)';
+            paramsInput.placeholder = 'Enter additional JSON parameters if needed...';
             break;
         case 'combined':
             parameterSubtitle.textContent = 'Add custom message to combine with prompt';


### PR DESCRIPTION
…riables (Cursor)

- Add 'Prompt Only' mode option to the UI
- Modify updateUIForPromptMode() to check for variable availability before showing variableEditorContainer
- Only display variable editor when selectedPromptContext has parameters.length > 0
- Update input labels and placeholders for all three modes: custom, prompt, and combined
- Improves UX by reducing visual clutter and following progressive disclosure principles

Resolves: https://github.com/plusplusoneplusplus/mcp/issues/364