### PR TITLE
fix: resolve GitHub Actions permission issues in package-extension wo…

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
     - name: Checkout repository
@@ -43,6 +46,7 @@ jobs:
     - name: Bump version and create PR
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd wu-wei
         # Configure git


### PR DESCRIPTION
…rkflow

- Add explicit permissions for contents:write and pull-requests:write to job
- Add GH_TOKEN environment variable for GitHub CLI compatibility
- Fixes 403 permission denied error when pushing version bump branches
- Enables automated version bumping and PR creation to work properly

This resolves the 'Permission to plusplusoneplusplus/mcp.git denied to github-actions[bot]' error.