### PR TITLE
fix: remove label arguments from automated PR creation

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -81,9 +81,7 @@ jobs:
 
         This PR was automatically created by the package-extension workflow." \
           --base main \
-          --head "$BRANCH_NAME" \
-          --label "automated" \
-          --label "version-bump")
+          --head "$BRANCH_NAME")
 
         # Enable auto-merge with squash strategy
         gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Summary

This PR removes the `--label` arguments from the GitHub CLI `pr create` command in the package-extension workflow.

## Changes

- Remove `--label "automated"` and `--label "version-bump"` arguments from the `gh pr create` command
- Simplify the PR creation process by relying on default labeling behavior

## Motivation

The label arguments were potentially causing issues in the automated workflow and are not necessary for the automated version bump PRs. The workflow will function more reliably without these optional parameters.

## Testing

- [x] Workflow syntax is valid
- [x] Change is minimal and focused
- [x] No breaking changes to the automation

## Related Issues

This is a maintenance improvement to the automated packaging workflow.

---

*This PR was created using GitHub Copilot following the submit.prompt.md workflow.*