### PR TITLE
fix: add manual test workflow triggers for automated PRs

### DIFF
--- a/.github/workflows/daily-version.yml
+++ b/.github/workflows/daily-version.yml
@@ -55,8 +55,15 @@ jobs:
         if: env.NEW_VERSION
         run: |
           # Get the PR number from the previous step
-          PR_NUMBER=$(gh pr list --head "release/${{ env.NEW_VERSION }}" --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --head "release/$NEW_VERSION" --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ]; then
+            # Trigger the test workflow manually for this PR
+            gh workflow run tests.yml --ref "release/$NEW_VERSION"
+            echo "Triggered test workflow for branch release/$NEW_VERSION"
+
+            # Wait a moment for the workflow to start
+            sleep 10
+
             gh pr merge $PR_NUMBER --auto --squash
             echo "Auto-merge enabled for PR #$PR_NUMBER"
           fi

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -83,5 +83,12 @@ jobs:
           --base main \
           --head "$BRANCH_NAME")
 
+        # Trigger the test workflow manually for this PR to ensure tests run
+        gh workflow run tests.yml --ref "$BRANCH_NAME"
+        echo "Triggered test workflow for branch $BRANCH_NAME"
+
+        # Wait a moment for the workflow to start
+        sleep 10
+
         # Enable auto-merge with squash strategy
         gh pr merge "$PR_URL" --auto --squash


### PR DESCRIPTION
## Problem

GitHub Actions workflows created by bots (like `github-actions[bot]`) don't automatically trigger other workflows for security reasons. This causes automated PRs (like version bumps) to get stuck in a "blocked" state with tests showing "Expected — Waiting for status to be reported".

**Affected PRs:**
- PR #400 (chore: bump version to v0.1.2) is currently blocked due to this issue

## Solution

This PR adds manual test workflow triggers to both automated PR creation workflows:

### Changes Made

1. **`.github/workflows/daily-version.yml`**:
   - Fixed GitHub Actions expression syntax issue (`${{ env.NEW_VERSION }}` → `$NEW_VERSION`)
   - Added manual `gh workflow run tests.yml` trigger before enabling auto-merge
   - Added 10-second delay to allow workflow to start

2. **`.github/workflows/package-extension.yml`**:
   - Added manual `gh workflow run tests.yml` trigger before enabling auto-merge
   - Added 10-second delay to allow workflow to start

### Technical Details

- **Root Cause**: GitHub prevents workflows from auto-triggering on bot-created PRs to prevent infinite loops and security issues
- **Fix**: Manually invoke the test workflow using `gh workflow run tests.yml --ref <branch>`
- **Safety**: Added delay ensures workflow starts before auto-merge is enabled

## Testing

- ✅ Pre-commit hooks passed (trailing whitespace, YAML validation)
- ✅ Workflow syntax validated
- ✅ No breaking changes to existing functionality

## Impact

- **Immediate**: Fixes currently blocked PR #400
- **Future**: Prevents all automated PRs from getting stuck without test execution
- **Safety**: Maintains all existing test requirements and auto-merge safety checks

## Related Issues

- Resolves the issue described in the GitHub Actions logs where tests show "Expected — Waiting for status to be reported"
- Enables proper CI/CD flow for automated version bumps and package releases