### PR TITLE
fix: add force push to package extension workflow

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -69,7 +69,7 @@ jobs:
         git commit -m "chore: bump version to v$NEW_VERSION"
 
         # Push the branch
-        git push origin "$BRANCH_NAME"
+        git push -f origin "$BRANCH_NAME"
 
         # Create pull request using GitHub CLI
         PR_URL=$(gh pr create \


### PR DESCRIPTION
## Summary

This PR improves the package extension workflow by adding force push capability for version bump branches.

## Changes Made

- Modified `.github/workflows/package-extension.yml` to use `git push -f` instead of `git push`
- Ensures branch updates work correctly when rebasing or amending commits during the packaging process

## Problem Solved

The current workflow may fail when attempting to push version bump branches if there are conflicts or if the branch needs to be updated. Adding force push ensures the automated packaging process can handle branch updates reliably.

## Risk Assessment

- **Low Risk**: This change only affects automated workflow branches, not user-facing code
- **Targeted Change**: Only impacts the package extension workflow's push behavior
- **Improves Reliability**: Prevents workflow failures due to push conflicts

## Testing

- [x] Workflow syntax is valid (pre-commit hooks passed)
- [x] Change is minimal and focused
- [x] No impact on existing functionality

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Changes are atomic and focused
- [x] Commit message follows conventional format