### PR TITLE
ci: prevent workflows from running when triggered by github-actions bot

### DIFF
--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    if: ${{ github.actor != 'github-actions[bot]' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Add condition to prevent GitHub Actions workflows from running when triggered by the `github-actions[bot]` user to prevent infinite loops and unnecessary runs from automated processes.

## Changes Made

- **extension-ci.yml**: Added `if: ${{ github.actor != 'github-actions[bot]' }}` to the test job
- **tests.yml**: Added `if: ${{ github.actor != 'github-actions[bot]' }}` to the test job

## Technical Details

This change prevents both CI workflows from executing when the triggering actor is `github-actions[bot]`, which commonly occurs when:
- Automated version bumps are pushed
- Other automated workflows push commits
- Bot-generated pull requests are created

## Benefits

- ✅ Prevents infinite loop scenarios with automated workflows
- ✅ Reduces unnecessary CI resource usage
- ✅ Maintains normal workflow execution for human-triggered events
- ✅ Simple, targeted solution with minimal impact

## Testing

- Pre-commit hooks passed successfully
- Changes are minimal and focused on workflow control logic
- No impact on actual test execution when triggered by humans

## Related Issues

This addresses potential workflow conflicts when automated processes trigger CI pipelines unnecessarily.

---
*Created with GitHub Copilot*