### PR TITLE
chore: disable scheduled runs for daily-version and package-extension workflows

### DIFF
--- a/.github/workflows/daily-version.yml
+++ b/.github/workflows/daily-version.yml
@@ -1,8 +1,8 @@
 name: Daily Version Bump
 
 on:
-  schedule:
-    - cron: "0 0 * * *"  # Every day at midnight UTC
+  # schedule:
+  #   - cron: "0 0 * * *"  # Every day at midnight UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -1,8 +1,8 @@
 name: Package Wu Wei Extension
 
 on:
-  schedule:
-    - cron: "0 0 * * *"  # Every day at midnight UTC
+  # schedule:
+  #   - cron: "0 0 * * *"  # Every day at midnight UTC
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

This PR disables the scheduled daily runs for two GitHub Actions workflows while preserving the ability to run them manually.

## Changes Made

- **daily-version.yml**: Commented out the daily cron schedule (0 0 * * *)
- **package-extension.yml**: Commented out the daily cron schedule (0 0 * * *)
- Maintained  triggers for manual execution when needed

## Rationale

- Prevents automated daily executions that may not be needed
- Reduces unnecessary CI/CD resource usage
- Allows for controlled, manual triggering when releases are actually needed
- Follows best practices for workflow automation management

## Testing

- ✅ Pre-commit hooks passed during commit
- ✅ No syntax errors in workflow YAML files
- ✅ Workflows can still be triggered manually via GitHub Actions UI

## Impact

- **Breaking Changes**: None
- **Backward Compatibility**: Full
- **Manual Action Required**: Workflows now need manual triggering instead of daily automation

This change improves workflow efficiency by removing automated daily runs while maintaining full functionality for manual execution.