### PR TITLE
Codex: refactor vector store into interface

### DIFF
--- a/docs/utils_overview.md
+++ b/docs/utils_overview.md
@@ -86,7 +86,8 @@ This document provides a high-level overview of the utilities available in the `
 - Supports persistent or in-memory storage and collection management.
 
 **Usage:**
-- Main class: `ChromaVectorStore`
+- Interface: `VectorStore`
+- Default implementation: `ChromaVectorStore`
     - `add(ids, embeddings, metadatas, documents)` to store data
     - `query(query_embeddings, n_results, where)` to retrieve similar vectors
     - `delete(ids)` to remove vectors

--- a/utils/segmenter/workflow.py
+++ b/utils/segmenter/workflow.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Optional, Dict, List, Any
 
 from utils.vector_store.vector_store import ChromaVectorStore
+from utils.vector_store.base import VectorStore
 from utils.vector_store.markdown_segmenter import MarkdownSegmenter
 from utils.segmenter.types import (
     SegmenterConfig,

--- a/utils/vector_store/__init__.py
+++ b/utils/vector_store/__init__.py
@@ -1,6 +1,7 @@
 """Vector store utilities."""
 
 from utils.vector_store.vector_store import ChromaVectorStore
+from utils.vector_store.base import VectorStore
 from utils.vector_store.markdown_table_segmenter import MarkdownTableSegmenter
 from utils.vector_store.markdown_segmenter import MarkdownSegmenter
 from utils.vector_store.embedding_service import (
@@ -12,6 +13,7 @@ from utils.vector_store.embedding_service import (
 )
 
 __all__ = [
+    "VectorStore",
     "ChromaVectorStore",
     "MarkdownTableSegmenter",
     "MarkdownSegmenter",

--- a/utils/vector_store/base.py
+++ b/utils/vector_store/base.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+
+class VectorStore(ABC):
+    """Abstract interface for vector store backends."""
+
+    @abstractmethod
+    def add(
+        self,
+        ids: List[str],
+        embeddings: List[List[float]],
+        metadatas: Optional[List[Dict[str, Any]]] = None,
+        documents: Optional[List[str]] = None,
+    ) -> None:
+        """Add records to the store."""
+
+    @abstractmethod
+    def query(
+        self,
+        query_embeddings: List[List[float]],
+        n_results: int = 5,
+        where: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Query for similar embeddings."""
+
+    @abstractmethod
+    def delete(self, ids: List[str]) -> None:
+        """Delete records by id."""
+
+    @abstractmethod
+    def list_collections(self) -> List[str]:
+        """Return all collection names."""
+
+    @abstractmethod
+    def get_collection(self, collection_name: str) -> None:
+        """Switch the active collection."""

--- a/utils/vector_store/vector_store.py
+++ b/utils/vector_store/vector_store.py
@@ -1,7 +1,9 @@
-from typing import List, Optional, Any, Dict
+from typing import Any, Dict, List, Optional
+
+from .base import VectorStore
 
 
-class ChromaVectorStore:
+class ChromaVectorStore(VectorStore):
     """
     Utility class for storing and accessing data through ChromaDB vector database.
     """


### PR DESCRIPTION
## Summary
- introduce a `VectorStore` interface for vector store implementations
- make `ChromaVectorStore` implement the new interface
- export `VectorStore` from vector store package
- update docs on new interface

## Testing
- `pre-commit run --files utils/vector_store/vector_store.py utils/vector_store/base.py utils/vector_store/__init__.py utils/segmenter/workflow.py docs/utils_overview.md`
- `pytest utils/vector_store/tests/test_vector_store.py -q` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*


------
https://chatgpt.com/codex/tasks/task_e_68637ad6021083229e16b457466da4df