### PR TITLE
fix: make wu-wei copy-webview script cross-platform compatible

### DIFF
--- a/wu-wei/package.json
+++ b/wu-wei/package.json
@@ -456,7 +456,7 @@
     "scripts": {
         "vscode:prepublish": "npm run package",
         "compile": "npm run clean && tsc -p ./ && npm run copy-webview",
-        "copy-webview": "cp -r src/webview out/",
+        "copy-webview": "node -e \"require('fs').cpSync('src/webview', 'out/webview', {recursive: true})\"",
         "watch": "npm run esbuild-watch",
         "package": "npm run clean && node esbuild.js --production && npm run copy-webview",
         "esbuild": "node esbuild.js",


### PR DESCRIPTION
## Summary

Replace Unix-specific `cp -r` command with Node.js `fs.cpSync()` for cross-platform compatibility in the Wu Wei extension build process.

## Changes Made

- **File Modified**: `wu-wei/package.json`
- **Change**: Updated the `copy-webview` script from `cp -r src/webview out/` to `node -e "require('fs').cpSync('src/webview', 'out/webview', {recursive: true})"`

## Problem Solved

The previous implementation used the Unix-specific `cp -r` command, which would fail on Windows systems. This change ensures the wu-wei extension build process works consistently across:

- ✅ Windows
- ✅ macOS  
- ✅ Linux

## Testing

- [x] Verified Node.js `fs.cpSync()` syntax is correct
- [x] Confirmed this is available in Node.js 16+ (project requirement)
- [x] Pre-commit hooks passed (end-of-file fixer applied)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Additional Context

This change improves the developer experience for contributors using Windows systems and ensures consistent build behavior across all supported platforms. The `fs.cpSync()` method was introduced in Node.js v16.7.0 and provides recursive copying functionality equivalent to `cp -r`.