### PR TITLE
refactor(wu-wei): replace chat.openAgent with chat.open + submit commands

### DIFF
--- a/wu-wei/src/agentManager/agentInterface.ts
+++ b/wu-wei/src/agentManager/agentInterface.ts
@@ -253,14 +253,30 @@ export class GitHubCopilotAgent extends AbstractAgent {
             await vscode.commands.executeCommand('workbench.action.chat.newChat');
 
             // Wait a moment for the chat to initialize
-            await new Promise(resolve => setTimeout(resolve, 500));
+            await new Promise(resolve => setTimeout(resolve, 2000));
 
             // Then open the agent with the query (don't prepend agentId if query already contains it)
             const finalQuery = query ? (query.includes('@') ? query : `${agentId} ${query}`) : agentId;
-            await vscode.commands.executeCommand('workbench.action.chat.openAgent', {
+
+            if (false) {
+                // old way
+                await vscode.commands.executeCommand('workbench.action.chat.openAgent', {
+                    query: finalQuery,
+                    isPartialQuery: !query
+                });
+            }
+
+            // Use workbench.action.chat.open with pre-filled query
+            await vscode.commands.executeCommand('workbench.action.chat.open', {
                 query: finalQuery,
-                isPartialQuery: !query
+                isPartialQuery: true // pre-fills input, doesn't send
             });
+
+            // Wait a moment for the chat to initialize
+            await new Promise(resolve => setTimeout(resolve, 2000));
+
+            // Submit the query
+            await vscode.commands.executeCommand('workbench.action.chat.submit');
 
             return {
                 success: true,
@@ -293,10 +309,19 @@ export class GitHubCopilotAgent extends AbstractAgent {
             const fullQuery = context ? `${question} Context: ${context}` : question;
 
             // Then execute the ask command
-            await vscode.commands.executeCommand('workbench.action.chat.openAgent', {
+            // await vscode.commands.executeCommand('workbench.action.chat.openAgent', {
+            //     query: fullQuery,
+            //     isPartialQuery: false
+            // });
+
+            // Use workbench.action.chat.open with pre-filled query
+            await vscode.commands.executeCommand('workbench.action.chat.open', {
                 query: fullQuery,
-                isPartialQuery: false
+                isPartialQuery: true // pre-fills input, doesn't send
             });
+
+            // Submit the query
+            await vscode.commands.executeCommand('workbench.action.chat.submit');
 
             return {
                 success: true,


### PR DESCRIPTION
## Summary

This PR refactors the Wu Wei agent interface to use the new VSCode chat command pattern:
- Replaces `workbench.action.chat.openAgent` with `workbench.action.chat.open` + `workbench.action.chat.submit`
- Updates both `handleOpenAgent` and `handleAskRequest` methods
- Comments out old code instead of removing it for reference
- Adds appropriate timing delays for chat initialization

## Changes Made

- **wu-wei/src/agentManager/agentInterface.ts**:
  - Updated `handleOpenAgent` method to use new command pattern
  - Updated `handleAskRequest` method to use new command pattern  
  - Preserved old code as comments for reference
  - Added timing delays between commands for proper initialization

## Technical Details

The new approach:
1. Uses `workbench.action.chat.open` with `isPartialQuery: true` to pre-fill the input
2. Follows with `workbench.action.chat.submit` to actually send the query
3. Includes timing delays to ensure proper chat initialization

## Test Plan

- [ ] Verify wu-wei agent interface compiles without errors
- [ ] Test agent communication functionality in VSCode environment
- [ ] Confirm chat commands work as expected with the new pattern

🤖 Generated with [Claude Code](https://claude.ai/code)