### PR TITLE
fix(kusto): Remove string truncation from DataFrame display formatting

### DIFF
--- a/plugins/kusto/tool.py
+++ b/plugins/kusto/tool.py
@@ -336,9 +336,8 @@ class KustoClient(KustoClientInterface):
         output.append(f"Query Results ({len(df)} rows, {len(df.columns)} columns)")
         output.append("=" * 50)
 
-        # Get max column width from formatting options
-        max_col_width = getattr(self, '_current_formatting_options', {}).get('max_column_width', 50)
-        output.append(df.to_string(index=False, max_colwidth=max_col_width))
+        # Display full strings without truncation
+        output.append(df.to_string(index=False))
         return "\n".join(output)
 
     def _format_medium_dataframe(self, df: pd.DataFrame) -> str:
@@ -361,15 +360,14 @@ class KustoClient(KustoClientInterface):
             output.append(f"• {col}: {dtype} ({unique_count} unique, {null_count} nulls)")
 
         # Sample data (first 10 rows)
-        max_col_width = getattr(self, '_current_formatting_options', {}).get('max_column_width', 40)
         output.append(f"\nSample Data (first 10 rows):")
-        output.append(df.head(10).to_string(index=False, max_colwidth=max_col_width))
+        output.append(df.head(10).to_string(index=False))
 
         # If more than 10 rows, show summary statistics for numeric columns
         numeric_cols = df.select_dtypes(include=[np.number]).columns
         if len(numeric_cols) > 0:
             output.append(f"\nNumeric Summary:")
-            output.append(df[numeric_cols].describe().to_string(max_colwidth=20))
+            output.append(df[numeric_cols].describe().to_string())
 
         return "\n".join(output)
 
@@ -407,19 +405,18 @@ class KustoClient(KustoClientInterface):
             output.append(f"• {col}: {dtype} ({unique_count:,} unique, {null_count:,} nulls{range_info})")
 
         # First 5 rows
-        max_col_width = formatting_options.get('max_column_width', 30)
         output.append(f"\nFirst 5 rows:")
-        output.append(df.head(5).to_string(index=False, max_colwidth=max_col_width))
+        output.append(df.head(5).to_string(index=False))
 
         # Last 5 rows
         output.append(f"\nLast 5 rows:")
-        output.append(df.tail(5).to_string(index=False, max_colwidth=max_col_width))
+        output.append(df.tail(5).to_string(index=False))
 
         # Summary statistics for numeric columns
         numeric_cols = df.select_dtypes(include=[np.number]).columns
         if len(numeric_cols) > 0:
             output.append(f"\nNumeric Summary (top 5 columns):")
-            output.append(df[numeric_cols[:5]].describe().to_string(max_colwidth=15))
+            output.append(df[numeric_cols[:5]].describe().to_string())
 
         return "\n".join(output)
 

--- a/utils/dataframe_manager/summarizer.py
+++ b/utils/dataframe_manager/summarizer.py
@@ -206,6 +206,7 @@ class DataFrameSummarizer(DataFrameSummarizerInterface):
                         max_rows=None,
                         max_cols=None,
                         show_dimensions=True,
+                        max_colwidth=None,  # Display full strings without truncation
                     )
 
                     if len(formatted.encode('utf-8')) <= max_size_bytes:
@@ -220,6 +221,7 @@ class DataFrameSummarizer(DataFrameSummarizerInterface):
                     formatted = col_truncated.to_string(
                         index=False,
                         show_dimensions=True,
+                        max_colwidth=None,  # Display full strings without truncation
                     )
 
                     if len(formatted.encode('utf-8')) <= max_size_bytes:


### PR DESCRIPTION
## Summary
- Removes string truncation from Kusto DataFrame display formatting
- Ensures full strings are displayed without "..." truncation indicators  
- Adds comprehensive test coverage to prevent regression

## Changes Made
- **KustoClient (`plugins/kusto/tool.py`)**:
  - Removed `max_colwidth` parameter from all `to_string()` calls in formatting methods
  - Updated `_format_small_dataframe()`, `_format_medium_dataframe()`, and `_format_large_dataframe()`
  
- **DataFrameSummarizer (`utils/dataframe_manager/summarizer.py`)**:
  - Added explicit `max_colwidth=None` to ensure full string display in table formatting
  
- **Test Coverage (`plugins/kusto/tests/test_kusto_client.py`)**:
  - Added `test_dataframe_formatting_no_string_truncation()` - tests all KustoClient formatting methods
  - Added `test_dataframe_summarizer_no_string_truncation()` - tests DataFrame summarizer formatting
  - Both tests verify that very long strings are displayed in full without truncation

## Test Plan
- [x] All existing Kusto tests pass (31/31)
- [x] All DataFrame manager tests pass (133/133) 
- [x] New tests specifically verify no string truncation occurs
- [x] Tests use very long strings (700+ characters) to ensure robust verification
- [x] Tests cover all DataFrame size categories (small ≤20, medium 21-1000, large >1000 rows)

## Breaking Changes
None - this change only removes artificial truncation, improving data visibility.

🤖 Generated with [Claude Code](https://claude.ai/code)