### PR TITLE
feat(browser): Add 'redact_secrets' option to BrowserClient for selec…

### DIFF
--- a/mcp_tools/browser/playwright_client.py
+++ b/mcp_tools/browser/playwright_client.py
@@ -198,10 +198,16 @@ class PlaywrightBrowserClient(IBrowserClient):
         self, url: str, wait_time: int = 30, headless: bool = True, options: Any = None
     ) -> Optional[str]:
         try:
-            html = await self.wrapper.get_page_html(
-                url, wait_until="networkidle", wait_time=wait_time
-            )
-            return html
+            # Create a new wrapper instance with the specified headless mode
+            async with PlaywrightWrapper(
+                browser_type=self.browser,
+                user_data_dir=self.user_data_dir,
+                headless=headless,
+            ) as temp_wrapper:
+                html = await temp_wrapper.get_page_html(
+                    url, wait_until="networkidle", wait_time=wait_time
+                )
+                return html
         except Exception:
             return None
 


### PR DESCRIPTION
…tive secret scanning

- Introduced a new boolean parameter 'redact_secrets' to control the scanning and redaction of potential secrets in HTML content.
- Updated logic to apply secret redaction only when 'redact_secrets' is enabled, improving performance and flexibility.
- Enhanced logging to summarize detected secrets based on the new configuration.
- Refactored related methods to ensure consistent behavior with the new option.

This change enhances security by allowing users to opt-in for secret scanning as needed.