### PR TITLE
fix: Remove unused parameters handling in format_result_as_text

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -309,11 +309,6 @@ def format_result_as_text(result: dict) -> str:
         return result.get("output", "")
     elif "html" in result:
         return f"HTML content (length: {result.get('html_length', 0)}):\n{result.get('html', '')}"
-    elif "parameters" in result:
-        params = result.get("parameters", {})
-        return "Environment parameters:\n" + "\n".join(
-            f"{k}: {v}" for k, v in params.items()
-        )
     else:
         # Generic formatting
         return "\n".join(f"{k}: {v}" for k, v in result.items() if k != "success")


### PR DESCRIPTION
## Summary
- Remove unused parameters condition in `format_result_as_text` function
- Simplify the function by removing dead code path that handles environment parameters
- No functional changes expected as this code path appears to be unused

## Changes Made
- Removed `elif "parameters" in result:` condition block in `format_result_as_text` function in `server/main.py`
- Cleaned up associated parameter formatting logic

## Test Plan
- [x] Existing tests should continue to pass
- [x] No functional changes expected since code path was unused
- [x] Pre-commit hooks passed successfully

🤖 Generated with [Claude Code](https://claude.ai/code)