### PR TITLE
Add plugin manager with refresh operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,5 @@ utils/secret_scanner/**/__pycache__/
 .claude/**/history/
 .claude/**/cache/
 .claude/**/node_modules/
+# External plugin clones
+plugins_external/

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ Tools are modular plugins registered through `mcp_tools`. Built-in utilities inc
 
 The web interface offers a Tools dashboard at `/tools` for browsing all registered tools and viewing their details.
 
+## Plugin Management
+
+External plugins can be installed by declaring them in `plugin_config.yaml`. Each
+entry should specify a `plugin_repo` in the form `owner/repository` and an optional
+`sub_dir` if the plugin lives in a subfolder. Example:
+
+```yaml
+plugins:
+  # - plugin_repo: "github_owner/repo"
+  #   sub_dir: "path/to/plugin"
+  #   type: "python"
+```
+
+Run the `mcp_admin` tool with the `refresh_plugins` operation to clone or update
+plugins based on this configuration. Pass `force=true` to remove all installed
+plugins before reinstalling.
+
 ## Running Tests
 
 Execute all test suites with:

--- a/mcp_tools/plugin_manager.py
+++ b/mcp_tools/plugin_manager.py
@@ -1,0 +1,91 @@
+import logging
+import subprocess
+import shutil
+from pathlib import Path
+from typing import List, Dict, Any
+
+import yaml
+
+from mcp_tools.plugin_config import config
+
+logger = logging.getLogger(__name__)
+
+# Path to plugin configuration YAML
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PLUGIN_CONFIG_PATH = REPO_ROOT / "plugin_config.yaml"
+
+# Directory where external plugins are installed
+EXTERNAL_PLUGINS_ROOT = REPO_ROOT / "plugins_external"
+
+# Directory containing built in plugins
+BUILTIN_PLUGINS_ROOT = REPO_ROOT / "plugins"
+
+
+def load_plugin_config() -> List[Dict[str, Any]]:
+    """Load plugin configuration from YAML."""
+    if not PLUGIN_CONFIG_PATH.exists():
+        logger.info("Plugin config not found, skipping load")
+        return []
+
+    with open(PLUGIN_CONFIG_PATH, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("plugins", [])
+
+
+def _clone_or_update(repo: str, dest: Path) -> None:
+    """Clone repo if dest does not exist, otherwise update with git pull."""
+    url = f"https://github.com/{repo}.git"
+    if dest.exists():
+        try:
+            subprocess.run([
+                "git",
+                "-C",
+                str(dest),
+                "pull",
+                "--ff-only",
+            ], check=True)
+            return
+        except Exception as e:
+            logger.warning(f"Failed to update {repo}: {e}, recloning")
+            shutil.rmtree(dest)
+    subprocess.run(["git", "clone", url, str(dest)], check=True)
+
+
+def refresh_plugins(force_clean: bool = False) -> List[Path]:
+    """Refresh plugins based on plugin config.
+
+    Args:
+        force_clean: If True, remove all external plugins before reinstalling.
+
+    Returns:
+        List of plugin root paths after refresh.
+    """
+    plugins = load_plugin_config()
+
+    if force_clean and EXTERNAL_PLUGINS_ROOT.exists():
+        shutil.rmtree(EXTERNAL_PLUGINS_ROOT)
+    EXTERNAL_PLUGINS_ROOT.mkdir(parents=True, exist_ok=True)
+
+    desired_repos = {}
+    plugin_roots = [BUILTIN_PLUGINS_ROOT]
+
+    for entry in plugins:
+        repo = entry.get("plugin_repo")
+        if not repo:
+            continue
+        repo_name = repo.split("/")[-1]
+        dest_dir = EXTERNAL_PLUGINS_ROOT / repo_name
+        _clone_or_update(repo, dest_dir)
+        sub_dir = entry.get("sub_dir")
+        plugin_root = dest_dir / sub_dir if sub_dir else dest_dir
+        plugin_roots.append(plugin_root)
+        desired_repos[repo_name] = dest_dir
+
+    # Remove extraneous plugin directories
+    for item in EXTERNAL_PLUGINS_ROOT.iterdir():
+        if item.is_dir() and item.name not in desired_repos:
+            shutil.rmtree(item)
+
+    # Update plugin roots in configuration
+    config.plugin_roots = plugin_roots
+    return plugin_roots

--- a/plugin_config.yaml
+++ b/plugin_config.yaml
@@ -1,0 +1,7 @@
+# Example plugin configuration. Uncomment and edit entries to install plugins.
+plugins:
+  # - plugin_repo: "plusplusoneplusplus/mcp"
+  #   sub_dir: "plugin/logcli"
+  #   type: "python"
+  # - plugin_repo: "tcauth/boltx_deploy"
+  #   type: "python"


### PR DESCRIPTION
## Summary
- introduce `plugin_manager` for cloning configured plugins
- add `plugin_config.yaml` example with commented entries
- ignore `plugins_external` directories
- extend `mcp_admin` tool with new `refresh_plugins` operation
- document plugin management in README

## Testing
- `pip install -e .` *(fails: Could not install dependencies)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6878fc38fcfc832fa403372e7c7a3fc6