### PR TITLE
Codex: add Playwright cookie retrieval with URL wait

### DIFF
--- a/mcp_tools/browser/README.md
+++ b/mcp_tools/browser/README.md
@@ -105,9 +105,18 @@ from mcp_tools.browser.client import BrowserClient
 async def example():
     # Get HTML from a webpage
     html = await BrowserClient.get_page_html("https://example.com")
-    
+
     # Take a screenshot of a webpage
     success = await BrowserClient.take_screenshot("https://example.com", "screenshot.png")
-    
+
+    # Launch login page and fetch cookies after URL match
+    cookies = await BrowserClient.get_cookies(
+        url="https://example.com/login",
+        wait_url="dashboard",
+        headless=False,
+    )
+    print(cookies)
+
 # Run the async example
-asyncio.run(example()) 
+asyncio.run(example())
+```

--- a/mcp_tools/browser/browser_client.py
+++ b/mcp_tools/browser/browser_client.py
@@ -93,8 +93,8 @@ class BrowserClient(BrowserClientInterface):
             "properties": {
                 "operation": {
                     "type": "string",
-                    "description": "The operation to perform (get_page_html, take_screenshot, get_page_markdown, capture_panels)",
-                    "enum": ["get_page_html", "take_screenshot", "get_page_markdown"],
+                    "description": "The operation to perform (get_page_html, take_screenshot, get_page_markdown, get_cookies, capture_panels)",
+                    "enum": ["get_page_html", "take_screenshot", "get_page_markdown", "get_cookies"],
                     "default": "get_page_markdown",
                 },
                 "url": {"type": "string", "description": "The URL to visit"},
@@ -117,6 +117,16 @@ class BrowserClient(BrowserClientInterface):
                     "type": "boolean",
                     "description": "Whether to include image references in the extracted markdown (for get_page_markdown)",
                     "default": False,
+                },
+                "wait_url": {
+                    "type": "string",
+                    "description": "URL substring or regex that indicates login success (for get_cookies)",
+                    "nullable": True,
+                },
+                "timeout": {
+                    "type": "integer",
+                    "description": "Seconds to wait for wait_url before returning cookies",
+                    "default": 60,
                 },
                 "headless": {
                     "type": "boolean",
@@ -329,6 +339,13 @@ class BrowserClient(BrowserClientInterface):
                     )
 
                 return result
+            elif operation == "get_cookies":
+                wait_url = arguments.get("wait_url")
+                timeout = arguments.get("timeout", 60)
+                cookies = await client.get_cookies_after_login(
+                    url, wait_url, headless=headless, timeout=timeout
+                )
+                return {"success": True, "cookies": cookies}
             elif operation == "capture_panels":
                 selector = arguments.get("selector", ".react-grid-item")
                 out_dir = arguments.get("out_dir", "charts")

--- a/mcp_tools/browser/interface.py
+++ b/mcp_tools/browser/interface.py
@@ -4,7 +4,7 @@ This module defines the core interfaces for browser automation clients.
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional, Union, Literal
+from typing import Dict, Any, Optional, Union, Literal, List
 
 
 class IBrowserClient(ABC):
@@ -92,5 +92,26 @@ class IBrowserClient(ABC):
                     - Path: Path to the panel image
                     - Content: The content inside the panel image recognized by OCR
                 - URL: Dashboard URL visited
+        """
+        pass
+
+    @abstractmethod
+    async def get_cookies_after_login(
+        self,
+        url: str,
+        wait_url: str,
+        headless: bool = False,
+        timeout: int = 60,
+    ) -> List[Dict[str, Any]]:
+        """Open a login page and return cookies after URL match.
+
+        Args:
+            url: Initial URL to open for login.
+            wait_url: URL substring or pattern indicating login success.
+            headless: Whether to run browser in headless mode.
+            timeout: Seconds to wait for URL to match before returning.
+
+        Returns:
+            List of cookies dictionaries.
         """
         pass

--- a/mcp_tools/browser/selenium_client.py
+++ b/mcp_tools/browser/selenium_client.py
@@ -10,7 +10,7 @@ import socket
 import subprocess
 import platform
 import asyncio
-from typing import Optional, Dict, Any, Union, Literal
+from typing import Optional, Dict, Any, Union, Literal, List
 from concurrent.futures import ThreadPoolExecutor
 
 from selenium import webdriver
@@ -46,6 +46,15 @@ class SeleniumBrowserClient(IBrowserClient):
         autoscroll: bool = False,
     ) -> int:
         raise NotImplementedError
+
+    async def get_cookies_after_login(
+        self,
+        url: str,
+        wait_url: str,
+        headless: bool = False,
+        timeout: int = 60,
+    ) -> List[Dict[str, Any]]:
+        raise NotImplementedError("Cookie retrieval is not supported for Selenium client")
 
     """Selenium-based browser client implementation.
     

--- a/mcp_tools/tests/test_browser_cookie_retrieval.py
+++ b/mcp_tools/tests/test_browser_cookie_retrieval.py
@@ -1,0 +1,46 @@
+"""Tests for retrieving cookies after manual Playwright login."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Import PlaywrightBrowserClient with graceful fallback when Playwright is missing
+try:  # pragma: no cover - import guard
+    from mcp_tools.browser.playwright_client import PlaywrightBrowserClient
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:  # pragma: no cover - executed when Playwright isn't installed
+    PlaywrightBrowserClient = None
+    PLAYWRIGHT_AVAILABLE = False
+
+
+@pytest.mark.asyncio
+async def test_get_cookies_after_login_url_match():
+    """Ensure cookies are returned after waiting for the target URL."""
+    if not PLAYWRIGHT_AVAILABLE:
+        pytest.skip("Playwright not available, skipping Playwright-specific test")
+
+    cookies = [{"name": "session", "value": "abc"}]
+
+    mock_page = MagicMock()
+    mock_page.wait_for_url = AsyncMock()
+
+    mock_wrapper = MagicMock()
+    mock_wrapper.open_page = AsyncMock(return_value=mock_page)
+    mock_wrapper.get_cookies = AsyncMock(return_value=cookies)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_wrapper)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    with patch(
+        "mcp_tools.browser.playwright_client.PlaywrightWrapper", return_value=mock_cm
+    ):
+        client = PlaywrightBrowserClient("chrome", "user_dir")
+        result = await client.get_cookies_after_login("https://login", "home")
+
+    assert result == cookies
+    mock_wrapper.open_page.assert_called_once_with(
+        "https://login", wait_until="domcontentloaded", wait_time=0
+    )
+    mock_page.wait_for_url.assert_called_once()
+    mock_wrapper.get_cookies.assert_called_once()
+

--- a/utils/playwright/playwright_wrapper.py
+++ b/utils/playwright/playwright_wrapper.py
@@ -343,6 +343,21 @@ class PlaywrightWrapper:
             raise RuntimeError("Page not initialized. Call open_page first.")
         return await self.page.content()
 
+    async def get_cookies(self) -> list:
+        """Return cookies for the current browser context.
+
+        Raises:
+            RuntimeError: If no browser context is initialized.
+
+        Returns:
+            List of cookie dictionaries as returned by Playwright.
+        """
+        if not self.context:
+            raise RuntimeError(
+                "Context not initialized. Use 'async with PlaywrightWrapper()' block."
+            )
+        return await self.context.cookies()
+
     async def close(self):
         # Close all pages
         for p in getattr(self, "pages", []):


### PR DESCRIPTION
## Summary
- support fetching cookies after manual login through Playwright
- expose new get_cookies operation with URL matching and timeout options
- document usage and add tests for cookie retrieval
- align cookie retrieval test with existing patterns

## Testing
- `uv run pytest mcp_tools/tests/test_browser_cookie_retrieval.py`


------
https://chatgpt.com/codex/tasks/task_e_689cad82c6fc8322bc326b27e5703118