### PR TITLE
Codex: save browser cookies to key-value store

### DIFF
--- a/mcp_tools/browser/README.md
+++ b/mcp_tools/browser/README.md
@@ -110,13 +110,16 @@ async def example():
     success = await BrowserClient.take_screenshot("https://example.com", "screenshot.png")
 
     # Launch login page and fetch cookies after URL match
-    cookies = await BrowserClient.get_cookies(
+    cookies_key = await BrowserClient.get_cookies(
         url="https://example.com/login",
         wait_url="dashboard",
         headless=False,
     )
-    print(cookies)
+    print(f"Cookies stored under key {cookies_key}")
 
 # Run the async example
 asyncio.run(example())
 ```
+
+By default, cookies are saved under a key in the format `browser.cookies/<domain>`
+derived from the login URL.

--- a/mcp_tools/browser/browser_client.py
+++ b/mcp_tools/browser/browser_client.py
@@ -128,6 +128,11 @@ class BrowserClient(BrowserClientInterface):
                     "description": "Seconds to wait for wait_url before returning cookies",
                     "default": 60,
                 },
+                "store_key": {
+                    "type": "string",
+                    "description": "Key to store retrieved cookies in KV store",
+                    "default": "browser.cookies/<domain>",
+                },
                 "headless": {
                     "type": "boolean",
                     "description": "Whether to run the browser in headless mode.",
@@ -342,10 +347,15 @@ class BrowserClient(BrowserClientInterface):
             elif operation == "get_cookies":
                 wait_url = arguments.get("wait_url")
                 timeout = arguments.get("timeout", 60)
-                cookies = await client.get_cookies_after_login(
-                    url, wait_url, headless=headless, timeout=timeout
+                store_key = arguments.get("store_key") or f"browser.cookies/{_get_domain_from_url(url)}"
+                cookies_key = await client.get_cookies_after_login(
+                    url,
+                    wait_url,
+                    headless=headless,
+                    timeout=timeout,
+                    store_key=store_key,
                 )
-                return {"success": True, "cookies": cookies}
+                return {"success": True, "cookies_key": cookies_key}
             elif operation == "capture_panels":
                 selector = arguments.get("selector", ".react-grid-item")
                 out_dir = arguments.get("out_dir", "charts")

--- a/mcp_tools/browser/interface.py
+++ b/mcp_tools/browser/interface.py
@@ -102,16 +102,19 @@ class IBrowserClient(ABC):
         wait_url: str,
         headless: bool = False,
         timeout: int = 60,
-    ) -> List[Dict[str, Any]]:
-        """Open a login page and return cookies after URL match.
+        store_key: Optional[str] = None,
+    ) -> str:
+        """Open a login page, store cookies and return the storage key.
 
         Args:
             url: Initial URL to open for login.
             wait_url: URL substring or pattern indicating login success.
             headless: Whether to run browser in headless mode.
             timeout: Seconds to wait for URL to match before returning.
+            store_key: Key under which cookies will be stored in the persisted KV store.
+                       Defaults to "browser.cookies/<domain>" when not provided.
 
         Returns:
-            List of cookies dictionaries.
+            The key where cookies were stored.
         """
         pass

--- a/mcp_tools/browser/selenium_client.py
+++ b/mcp_tools/browser/selenium_client.py
@@ -53,11 +53,14 @@ class SeleniumBrowserClient(IBrowserClient):
         wait_url: str,
         headless: bool = False,
         timeout: int = 60,
-    ) -> List[Dict[str, Any]]:
-        raise NotImplementedError("Cookie retrieval is not supported for Selenium client")
+        store_key: Optional[str] = None,
+    ) -> str:
+        raise NotImplementedError(
+            "Cookie retrieval is not supported for Selenium client"
+        )
 
     """Selenium-based browser client implementation.
-    
+
     This class provides a browser automation implementation using Selenium WebDriver.
     It supports Chrome and Edge browsers.
     """

--- a/mcp_tools/tests/test_browser_cookie_retrieval.py
+++ b/mcp_tools/tests/test_browser_cookie_retrieval.py
@@ -2,6 +2,7 @@
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
+from mcp_tools.kv_store.tool import _kv_store
 
 # Import PlaywrightBrowserClient with graceful fallback when Playwright is missing
 try:  # pragma: no cover - import guard
@@ -14,7 +15,7 @@ except ImportError:  # pragma: no cover - executed when Playwright isn't install
 
 @pytest.mark.asyncio
 async def test_get_cookies_after_login_url_match():
-    """Ensure cookies are returned after waiting for the target URL."""
+    """Ensure cookies are saved after waiting for the target URL."""
     if not PLAYWRIGHT_AVAILABLE:
         pytest.skip("Playwright not available, skipping Playwright-specific test")
 
@@ -31,16 +32,53 @@ async def test_get_cookies_after_login_url_match():
     mock_cm.__aenter__ = AsyncMock(return_value=mock_wrapper)
     mock_cm.__aexit__ = AsyncMock(return_value=None)
 
+    _kv_store.clear()
+
     with patch(
         "mcp_tools.browser.playwright_client.PlaywrightWrapper", return_value=mock_cm
     ):
         client = PlaywrightBrowserClient("chrome", "user_dir")
-        result = await client.get_cookies_after_login("https://login", "home")
+        result = await client.get_cookies_after_login(
+            "https://login", "home", store_key="test_cookies"
+        )
 
-    assert result == cookies
+    assert result == "test_cookies"
+    assert _kv_store.get("test_cookies") == cookies
     mock_wrapper.open_page.assert_called_once_with(
         "https://login", wait_until="domcontentloaded", wait_time=0
     )
     mock_page.wait_for_url.assert_called_once()
     mock_wrapper.get_cookies.assert_called_once()
 
+
+@pytest.mark.asyncio
+async def test_get_cookies_after_login_default_key():
+    """Ensure cookies are saved under a domain-based key when none provided."""
+    if not PLAYWRIGHT_AVAILABLE:
+        pytest.skip("Playwright not available, skipping Playwright-specific test")
+
+    cookies = [{"name": "session", "value": "abc"}]
+
+    mock_page = MagicMock()
+    mock_page.wait_for_url = AsyncMock()
+
+    mock_wrapper = MagicMock()
+    mock_wrapper.open_page = AsyncMock(return_value=mock_page)
+    mock_wrapper.get_cookies = AsyncMock(return_value=cookies)
+
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_wrapper)
+    mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+    _kv_store.clear()
+
+    with patch(
+        "mcp_tools.browser.playwright_client.PlaywrightWrapper", return_value=mock_cm
+    ):
+        client = PlaywrightBrowserClient("chrome", "user_dir")
+        result = await client.get_cookies_after_login(
+            "https://example.com/login", "home"
+        )
+
+    assert result == "browser.cookies/example.com"
+    assert _kv_store.get("browser.cookies/example.com") == cookies


### PR DESCRIPTION
## Summary
- persist login cookies in shared KV store and return storage key
- add `store_key` option to browser client interface and tool
- default cookie key uses `browser.cookies/<domain>` when none provided
- update docs and tests for KV-backed cookie retrieval

## Testing
- `uvx pre-commit run --files mcp_tools/browser/interface.py mcp_tools/browser/playwright_client.py mcp_tools/browser/browser_client.py mcp_tools/browser/selenium_client.py mcp_tools/tests/test_browser_cookie_retrieval.py mcp_tools/browser/README.md`
- `uvx --with pytest-asyncio --with psutil --with pydantic --with pyyaml --with detect-secrets pytest mcp_tools/tests/test_browser_cookie_retrieval.py` *(skipped: Playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689cbca2cbb8832295902086ed17b0e5