### PR TITLE
perf: add npm caching to CI workflow to reduce build times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
             args: ''
 
     runs-on: ${{ matrix.platform }}
-    defaults:
-      run:
-        working-directory: ./server-ui
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +33,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: 'package-lock.json'
+          cache-dependency-path: 'server-ui/package-lock.json'
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
@@ -51,9 +48,11 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Install frontend dependencies
+        working-directory: ./server-ui
         run: npm install
 
       - name: Run frontend tests
+        working-directory: ./server-ui
         run: npm run build
 
       - name: Rust cache
@@ -62,9 +61,11 @@ jobs:
           workspaces: './server-ui/src-tauri -> target'
 
       - name: Run Rust tests
+        working-directory: ./server-ui
         run: cd src-tauri && cargo test
 
       - name: Run Rust clippy
+        working-directory: ./server-ui
         run: cd src-tauri && cargo clippy -- -D warnings
 
       - name: Build Tauri app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'server-ui/package-lock.json'
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
-          cache-dependency-path: 'server-ui/package-lock.json'
+          cache-dependency-path: 'package-lock.json'
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
This PR adds npm caching to the GitHub Actions CI workflow to reduce frontend dependency installation time.

**Changes:**
- Add npm cache configuration to Node.js setup in `.github/workflows/ci.yml`
- Cache dependency path points to `server-ui/package-lock.json` from repository root
- Reduces frontend dependency installation time in CI

**Fixes Applied:**
- **Fix 1:** Corrected cache-dependency-path to be relative to working directory 
- **Fix 2:** Moved Node.js setup outside working-directory defaults to resolve path resolution issues
- **Fix 3:** Added explicit working-directory to individual steps that need it
- Resolves 'Some specified paths were not resolved' error on all platforms (Windows, macOS, Ubuntu)

**Technical Details:**
The issue was that `actions/setup-node` runs in the repository root context, but the job had `defaults.run.working-directory` set to `./server-ui`. This caused the cache dependency path to be resolved incorrectly. By moving the Node.js setup outside the working-directory defaults and using the full path from repo root, the caching now works correctly.

**Benefits:**
- Faster CI builds through npm dependency caching
- Reduced resource usage  
- Better developer experience with quicker feedback
- Cross-platform compatibility (Windows, macOS, Ubuntu)

The existing Rust cache is preserved and will continue to work as before.